### PR TITLE
Add github security

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,23 @@
+name: Dependency Submission
+on:
+  push:
+    branches: ['main', 'develop']
+  pull_request:
+permissions:
+  contents: write
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4
+    - name: Setup Java
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'adopt'
+        java-version: 8
+    - name: Generate and submit dependency graph
+      uses: gradle/actions/dependency-submission@v4
+      with:
+        # The gradle project is not in the root of the repository.
+        build-root-directory: tools/gradlew


### PR DESCRIPTION
**What does this PR do?**
Add dependency-submission security for dependabot alerts.

**Why are these changes required?**
For security reason.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
