### PR TITLE
feat(config): sync all config files with java-tron upstream

### DIFF
--- a/conf/main_net_config.conf
+++ b/conf/main_net_config.conf
@@ -1,85 +1,78 @@
+net {
+  # type is deprecated and has no effect.
+  # type = mainnet
+}
+
 storage {
   # Directory for storing persistent data
-  db.engine = "LEVELDB",
+  db.engine = "LEVELDB",  // deprecated for arm, because arm only support  "ROCKSDB".
   db.sync = false,
   db.directory = "database",
-  index.directory = "index",
+
+  # Whether to write transaction result in transactionRetStore
   transHistory.switch = "on",
-  # You can custom these 14 databases' configs:
 
-  # account, account-index, asset-issue, block, block-index,
-  # block_KDB, peers, properties, recent-block, trans,
-  # utxo, votes, witness, witness_schedule.
-
-  # Otherwise, db configs will remain default and data will be stored in
-  # the path of "output-directory" or which is set by "-d" ("--output-directory").
-
-  # setting can impove leveldb performance .... start
+  # setting can improve leveldb performance .... start, deprecated for arm
   # node: if this will increase process fds,you may be check your ulimit if 'too many open files' error occurs
   # see https://github.com/tronprotocol/tips/blob/master/tip-343.md for detail
-  # if you find block sync has lower performance,you can try  this  settings
-  #default = {
+  # if you find block sync has lower performance, you can try this settings
+  # default = {
   #  maxOpenFiles = 100
-  #}
-  #defaultM = {
+  # }
+  # defaultM = {
   #  maxOpenFiles = 500
-  #}
-  #defaultL = {
+  # }
+  # defaultL = {
   #  maxOpenFiles = 1000
-  #}
-  # setting can impove leveldb performance .... end
+  # }
+  # setting can improve leveldb performance .... end, deprecated for arm
 
-  # Attention: name is a required field that must be set !!!
+  # You can customize the configuration for each database. Otherwise, the database settings will use
+  # their defaults, and data will be stored in the "output-directory" or in the directory specified
+  # by the "-d" or "--output-directory" option. Attention: name is a required field that must be set!
+  # In this configuration, the name and path properties take effect for both LevelDB and RocksDB storage engines,
+  # while the additional properties (such as createIfMissing, paranoidChecks, compressionType, etc.) only take effect when using LevelDB.
   properties = [
-    //    {
-    //      name = "account",
-    //      path = "storage_directory_test",
-    //      createIfMissing = true,
-    //      paranoidChecks = true,
-    //      verifyChecksums = true,
-    //      compressionType = 1,        // compressed with snappy
-    //      blockSize = 4096,           // 4  KB =         4 * 1024 B
-    //      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
-    //      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
-    //      maxOpenFiles = 100
-    //    },
-    //    {
-    //      name = "account-index",
-    //      path = "storage_directory_test",
-    //      createIfMissing = true,
-    //      paranoidChecks = true,
-    //      verifyChecksums = true,
-    //      compressionType = 1,        // compressed with snappy
-    //      blockSize = 4096,           // 4  KB =         4 * 1024 B
-    //      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
-    //      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
-    //      maxOpenFiles = 100
-    //    },
+    #    {
+    #      name = "account",
+    #      path = "storage_directory_test",
+    #      createIfMissing = true, // deprecated for arm start
+    #      paranoidChecks = true,
+    #      verifyChecksums = true,
+    #      compressionType = 1,        // compressed with snappy
+    #      blockSize = 4096,           // 4  KB =         4 * 1024 B
+    #      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
+    #      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
+    #      maxOpenFiles = 100 // deprecated for arm end
+    #    },
+    #    {
+    #      name = "account-index",
+    #      path = "storage_directory_test",
+    #      createIfMissing = true,
+    #      paranoidChecks = true,
+    #      verifyChecksums = true,
+    #      compressionType = 1,        // compressed with snappy
+    #      blockSize = 4096,           // 4  KB =         4 * 1024 B
+    #      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
+    #      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
+    #      maxOpenFiles = 100
+    #    },
   ]
 
   needToUpdateAsset = true
 
-  //dbsettings is needed when using rocksdb as the storage implement (db.engine="ROCKSDB").
-  //we'd strongly recommend that do not modify it unless you know every item's meaning clearly.
+  # dbsettings is needed when using rocksdb as the storage implement (db.engine="ROCKSDB").
+  # we'd strongly recommend that do not modify it unless you know every item's meaning clearly.
   dbSettings = {
     levelNumber = 7
-    //compactThreads = 32
+    # compactThreads = 32
     blocksize = 64  // n * KB
     maxBytesForLevelBase = 256  // n * MB
     maxBytesForLevelMultiplier = 10
     level0FileNumCompactionTrigger = 4
     targetFileSizeBase = 256  // n * MB
     targetFileSizeMultiplier = 1
-  }
-
-  //backup settings when using rocks db as the storage implement (db.engine="ROCKSDB").
-  //if you want to use the backup plugin, please confirm set the db.engine="ROCKSDB" above.
-  backup = {
-    enable = false  // indicate whether enable the backup plugin
-    propPath = "prop.properties" // record which bak directory is valid
-    bak1path = "bak1/database" // you must set two backup directories to prevent application halt unexpected(e.g. kill -9).
-    bak2path = "bak2/database"
-    frequency = 10000   // indicate backup db once every 10000 blocks processed.
+    maxOpenFiles = 5000
   }
 
   balance.history.lookup = false
@@ -90,11 +83,14 @@ storage {
   # the estimated number of block transactions (default 1000, min 100, max 10000).
   # so the total number of cached transactions is 65536 * txCache.estimatedTransactions
   # txCache.estimatedTransactions = 1000
-  # if true, transaction cache initialization will be faster. default false
-  # txCache.initOptimization = true
+
+  # if true, transaction cache initialization will be faster. Default: false
+  txCache.initOptimization = true
+
+  # The number of blocks flushed to db in each batch during node syncing. Default: 1
+  # snapshot.maxFlushCount = 1
 
   # data root setting, for check data, currently, only reward-vi is used.
-
   # merkleRoot = {
   # reward-vi = 9debcb9924055500aaae98cdee10501c5c39d4daa75800a996f4bdda73dbccd8 // main-net, Sha256Hash, hexString
   # }
@@ -130,18 +126,27 @@ node.backup {
   ]
 }
 
+# Specify the algorithm for generating a public key from private key. To avoid forks, please do not modify it
 crypto {
   engine = "eckey"
 }
-# prometheus metrics start
-# node.metrics = {
-#  prometheus{
-#    enable=true
-#    port="9527"
-#  }
-# }
 
-# prometheus metrics end
+node.metrics = {
+  # prometheus metrics
+  prometheus {
+    enable = false
+    port = 9527
+  }
+
+  # influxdb metrics
+  storageEnable = false # Whether write metrics data into InfluxDb. Default: false.
+  influxdb {
+    ip = ""
+    port = 8086
+    database = ""
+    metricsReportInterval = 10
+  }
+}
 
 node {
   # trust node for solidity node
@@ -156,10 +161,7 @@ node {
   connection.timeout = 2
 
   fetchBlock.timeout = 200
-
-  tcpNettyWorkThreadNum = 0
-
-  udpNettyWorkThreadNum = 1
+  # syncFetchBatchNum = 2000
 
   # Number of validate sign thread, default availableProcessors
   # validateSignThreadNum = 16
@@ -176,11 +178,23 @@ node {
 
   minParticipationRate = 15
 
+  # allowShieldedTransactionApi = true
+
+  # openPrintLog = true
+
+  # If set to true, SR packs transactions into a block in descending order of fee; otherwise, it packs
+  # them based on their receive timestamp. Default: false
+  # openTransactionSort = false
+
+  # The threshold for the number of broadcast transactions received from each peer every second,
+  # transactions exceeding this threshold will be discarded
+  # maxTps = 1000
+
   isOpenFullTcpDisconnect = false
   inactiveThreshold = 600 //seconds
 
   p2p {
-    version = 11111 # mainnet:11111; nile testnet:201910292
+    version = 11111 # Mainnet:11111; Nile:201910292; Shasta:1
   }
 
   active = [
@@ -240,17 +254,23 @@ node {
     # The maximum size of header list allowed to be received, default 8192
     # maxHeaderListSize =
 
+    # The number of RST_STREAM frames allowed to be sent per connection per period for grpc, by default there is no limit.
+    # maxRstStream =
+
+    # The number of seconds per period for grpc
+    # secondsPerWindow =
+
     # Transactions can only be broadcast if the number of effective connections is reached.
     minEffectiveConnection = 1
 
-    # The switch of the reflection service, effective for all gRPC services
-    # reflectionService = true
+    # The switch of the reflection service, effective for all gRPC services, used for grpcurl tool. Default: false
+    reflectionService = false
   }
 
   # number of solidity thread in the FullNode.
   # If accessing solidity rpc and http interface timeout, could increase the number of threads,
   # The default value is the number of cpu cores of the machine.
-  #solidity.threads = 8
+  # solidity.threads = 8
 
   # Limits the maximum percentage (default 75%) of producing block interval
   # to provide sufficient time to perform other operations e.g. broadcast block
@@ -259,21 +279,24 @@ node {
   # Limits the maximum number (default 700) of transaction from network layer
   # netMaxTrxPerSecond = 700
 
-  # Whether to enable the node detection function, default false
+  # Whether to enable the node detection function. Default: false
   # nodeDetectEnable = false
 
-  # use your ipv6 address for node discovery and tcp connection, default false
+  # use your ipv6 address for node discovery and tcp connection. Default: false
   # enableIpv6 = false
 
-  # if your node's highest block num is below than all your pees', try to acquire new connection. default false
+  # if your node's highest block num is below than all your pees', try to acquire new connection. Default: false
   # effectiveCheckEnable = false
 
   # Dynamic loading configuration function, disabled by default
-  # dynamicConfig = {
-  # enable = false
-  # Configuration file change check interval, default is 600 seconds
-  # checkInterval = 600
-  # }
+  dynamicConfig = {
+    # enable = false
+    # checkInterval = 600 // Check interval of Configuration file's change, default is 600 seconds
+  }
+
+  # Whether to continue broadcast transactions after at least maxUnsolidifiedBlocks are not solidified. Default: false
+  # unsolidifiedBlockCheck = false
+  # maxUnsolidifiedBlocks = 54
 
   dns {
     # dns urls to get nodes, url format tree://{pubkey}@{domain}, default empty
@@ -281,7 +304,7 @@ node {
       #"tree://AKMQMNAJJBL73LXWPXDI4I5ZWWIZ4AWO34DWQ636QOBBXNFXH3LQS@main.trondisco.net",
     ]
 
-    # enable or disable dns publish, default false
+    # enable or disable dns publish. Default: false
     # publish = false
 
     # dns domain to publish nodes, required if publish is true
@@ -327,22 +350,20 @@ node {
     # awsHostZoneId = "your-host-zone-id"
   }
 
-  # open the history query APIs(http&GRPC) when node is a lite fullNode,
-  # like {getBlockByNum, getBlockByID, getTransactionByID...}.
-  # default: false.
+  # open the history query APIs(http&GRPC) when node is a lite FullNode,
+  # like {getBlockByNum, getBlockByID, getTransactionByID...}. Default: false.
   # note: above APIs may return null even if blocks and transactions actually are on the blockchain
-  # when opening on a lite fullnode. only open it if the consequences being clearly known
+  # when opening on a lite FullNode. only open it if the consequences being clearly known
   # openHistoryQueryWhenLiteFN = false
 
   jsonrpc {
-    # Note: If you turn on jsonrpc and run it for a while and then turn it off, you will not
-    # be able to get the data from eth_getLogs for that period of time.
-
-    # httpFullNodeEnable = true
+    # Note: Before release_4.8.1, if you turn on jsonrpc and run it for a while and then turn it off,
+    # you will not be able to get the data from eth_getLogs for that period of time. Default: false
+    # httpFullNodeEnable = false
     # httpFullNodePort = 8545
-    # httpSolidityEnable = true
+    # httpSolidityEnable = false
     # httpSolidityPort = 8555
-    # httpPBFTEnable = true
+    # httpPBFTEnable = false
     # httpPBFTPort = 8565
 
     # The maximum blocks range to retrieve logs for eth_getLogs, default value is 5000,
@@ -352,27 +373,26 @@ node {
     # The maximum number of allowed topics within a topic criteria, default value is 1000,
     # should be > 0, otherwise means no limit.
     maxSubTopics = 1000
+    # Allowed maximum number for blockFilter
+    maxBlockFilterNum = 50000
   }
 
-  # Disabled api list, it will work for http, rpc and pbft, both fullnode and soliditynode,
-  # but not jsonrpc.
-  # Sample: The setting is case insensitive, GetNowBlock2 is equal to getnowblock2
-  #
-  # disabledApi = [
-  #   "getaccount",
-  #   "getnowblock2"
-  # ]
+  # Disabled api list, it will work for http, rpc and pbft, both FullNode and SolidityNode,
+  # but not jsonrpc. The setting is case insensitive, GetNowBlock2 is equal to getnowblock2
+  disabledApi = [
+    #  "getaccount",
+    #  "getnowblock2"
+  ]
 
 }
 
 ## rate limiter config
 rate.limiter = {
-  # Every api could be set a specific rate limit strategy. Three strategy are supported:GlobalPreemptibleAdapter、IPQPSRateLimiterAdapte、QpsRateLimiterAdapter
-  # GlobalPreemptibleAdapter: permit is the number of preemptible resource, every client must apply one resourse
-  #       before do the request and release the resource after got the reponse automaticlly. permit should be a Integer.
+  # Every api could only set a specific rate limit strategy. Three blocking strategy are supported:
+  # GlobalPreemptibleAdapter: The number of preemptible resource or maximum concurrent requests globally.
   # QpsRateLimiterAdapter: qps is the average request count in one second supported by the server, it could be a Double or a Integer.
   # IPQPSRateLimiterAdapter: similar to the QpsRateLimiterAdapter, qps could be a Double or a Integer.
-  # If do not set, the "default strategy" is set.The "default startegy" is based on QpsRateLimiterAdapter, the qps is set as 10000.
+  # If not set, QpsRateLimiterAdapter with qps=1000 is the default strategy.
   #
   # Sample entries:
   #
@@ -416,10 +436,16 @@ rate.limiter = {
     #  },
   ]
 
+  p2p = {
+    # syncBlockChain = 3.0
+    # fetchInvData = 3.0
+    # disconnect = 1.0
+  }
+
   # global qps, default 50000
-  # global.qps = 50000
+  global.qps = 50000
   # IP-based global qps, default 10000
-  # global.ip.qps = 10000
+  global.ip.qps = 10000
 }
 
 
@@ -434,17 +460,17 @@ seed.node = {
   # ]
   ip.list = [
     "3.225.171.164:18888",
-    "52.53.189.99:18888",
-    "18.196.99.16:18888",
-    "34.253.187.192:18888",
+    "52.8.46.215:18888",
+    "3.79.71.167:18888",
+    "108.128.110.16:18888",
     "18.133.82.227:18888",
-    "35.180.51.163:18888",
-    "54.252.224.209:18888",
+    "35.180.81.133:18888",
+    "13.210.151.5:18888",
     "18.231.27.82:18888",
-    "52.15.93.92:18888",
-    "34.220.77.106:18888",
+    "3.12.212.122:18888",
+    "52.24.128.7:18888",
     "15.207.144.3:18888",
-    "13.124.62.58:18888",
+    "3.39.38.55:18888",
     "54.151.226.240:18888",
     "35.174.93.198:18888",
     "18.210.241.149:18888",
@@ -629,34 +655,33 @@ genesis.block = {
     }
   ]
 
-  timestamp = "0" #2017-8-26 12:00:00
+  timestamp = "0" # Genesis block timestamp, milli seconds
 
   parentHash = "0xe58f33f9baf9305dc6f82b9f1934ea8f0ade2defb951258d50167028c780351f"
 }
 
-// Optional.The default is empty.
-// It is used when the witness account has set the witnessPermission.
-// When it is not empty, the localWitnessAccountAddress represents the address of the witness account,
-// and the localwitness is configured with the private key of the witnessPermissionAddress in the witness account.
-// When it is empty,the localwitness is configured with the private key of the witness account.
-
-//localWitnessAccountAddress =
+# Optional. The default is empty. It is used when the witness account has set the witnessPermission.
+# When it is not empty, the localWitnessAccountAddress represents the address of the witness account,
+# and the localwitness is configured with the private key of the witnessPermissionAddress in the witness account.
+# When it is empty,the localwitness is configured with the private key of the witness account.
+# localWitnessAccountAddress =
 
 localwitness = [
 ]
 
-#localwitnesskeystore = [
+# localwitnesskeystore = [
 #  "localwitnesskeystore.json"
-#]
+# ]
 
 block = {
   needSyncCheck = true
-  maintenanceTimeInterval = 21600000
-  proposalExpireTime = 259200000 // 3 day: 259200000(ms)
+  maintenanceTimeInterval = 21600000 // 6 hours: 21600000(ms)
+  proposalExpireTime = 259200000 // default value: 3 days: 259200000(ms), Note: this value is controlled by committee proposal
+  # checkFrozenTime = 1 // for test only
 }
 
 # Transaction reference block, default is "solid", configure to "head" may cause TaPos error
-# trx.reference.block = "solid" // head;solid;
+trx.reference.block = "solid" // "head" or "solid"
 
 # This property sets the number of milliseconds after the creation of the transaction that is expired, default value is  60000.
 # trx.expiration.timeInMilliseconds = 60000
@@ -667,30 +692,78 @@ vm = {
   minTimeRatio = 0.0
   maxTimeRatio = 5.0
   saveInternalTx = false
+  # lruCacheSize = 500
+  # vmTrace = false
 
-  # Indicates whether the node stores featured internal transactions, such as freeze, vote and so on
+  # Indicates whether the node stores featured internal transactions, such as freeze, vote and so on. Default: false.
   # saveFeaturedInternalTx = false
 
-  # Indicates whether the node stores the details of the internal transactions generated by the
-  # CANCELALLUNFREEZEV2 opcode, such as bandwidth/energy/tronpower cancel amount.
+  # Indicates whether the node stores the details of the internal transactions generated by the CANCELALLUNFREEZEV2 opcode,
+  # such as bandwidth/energy/tronpower cancel amount. Default: false.
   # saveCancelAllUnfreezeV2Details = false
 
   # In rare cases, transactions that will be within the specified maximum execution time (default 10(ms)) are re-executed and packaged
   # longRunningTime = 10
 
-  # Indicates whether the node support estimate energy API.
+  # Indicates whether the node support estimate energy API. Default: false.
   # estimateEnergy = false
 
-  # Indicates the max retry time for executing transaction in estimating energy.
+  # Indicates the max retry time for executing transaction in estimating energy. Default 3.
   # estimateEnergyMaxRetry = 3
 }
 
+# These parameters are designed for private chain testing only and cannot be freely switched on or off in production systems.
 committee = {
   allowCreationOfContracts = 0  //mainnet:0 (reset by committee),test:1
   allowAdaptiveEnergy = 0  //mainnet:0 (reset by committee),test:1
+  # allowCreationOfContracts = 0
+  # allowMultiSign = 0
+  # allowAdaptiveEnergy = 0
+  # allowDelegateResource = 0
+  # allowSameTokenName = 0
+  # allowTvmTransferTrc10 = 0
+  # allowTvmConstantinople = 0
+  # allowTvmSolidity059 = 0
+  # forbidTransferToContract = 0
+  # allowShieldedTRC20Transaction = 0
+  # allowTvmIstanbul = 0
+  # allowMarketTransaction = 0
+  # allowProtoFilterNum = 0
+  # allowAccountStateRoot = 0
+  # changedDelegation = 0
+  # allowPBFT = 0
+  # pBFTExpireNum = 0
+  # allowTransactionFeePool = 0
+  # allowBlackHoleOptimization = 0
+  # allowNewResourceModel = 0
+  # allowReceiptsMerkleRoot = 0
+  # allowTvmFreeze = 0
+  # allowTvmVote = 0
+  # unfreezeDelayDays = 0
+  # allowTvmLondon = 0
+  # allowTvmCompatibleEvm = 0
+  # allowNewRewardAlgorithm = 0
+  # allowAccountAssetOptimization = 0
+  # allowAssetOptimization = 0
+  # allowNewReward = 0
+  # memoFee = 0
+  # allowDelegateOptimization = 0
+  # allowDynamicEnergy = 0
+  # dynamicEnergyThreshold = 0
+  # dynamicEnergyMaxFactor = 0
+  # allowTvmShangHai = 0
+  # allowOldRewardOpt = 0
+  # allowEnergyAdjustment = 0
+  # allowStrictMath = 0
+  # allowTvmCancun = 0
+  # allowTvmBlob = 0
+  # consensusLogicOptimization = 0
+  # allowOptimizedReturnValueOfChainId = 0
+  # allowTvmOsaka = 0
 }
 
 event.subscribe = {
+  enable = false // enable event subscribe, replaces deprecated CLI flag --es
   native = {
     useNativeQueue = true // if true, use native message queue, else use event plugin.
     bindport = 5555 // bind port
@@ -703,10 +776,10 @@ event.subscribe = {
 
   path = "" // absolute path of plugin
   server = "" // target server address to receive event triggers
-  // dbname|username|password, if you want to create indexes for collections when the collections
-  // are not exist, you can add version and set it to 2, as dbname|username|password|version
-  // if you use version 2 and one collection not exists, it will create index automaticaly;
-  // if you use version 2 and one collection exists, it will not create index, you must create index manually;
+  # dbname|username|password, if you want to create indexes for collections when the collections
+  # are not exist, you can add version and set it to 2, as dbname|username|password|version
+  # if you use version 2 and one collection not exists, it will create index automaticaly;
+  # if you use version 2 and one collection exists, it will not create index, you must create index manually;
   dbconfig = ""
   contractParse = true
   topics = [
@@ -714,17 +787,17 @@ event.subscribe = {
       triggerName = "block" // block trigger, the value can't be modified
       enable = false
       topic = "block" // plugin topic, the value could be modified
-      solidified = false // if set true, just need solidified block, default is false
+      solidified = false // if set true, just need solidified block. Default: false
     },
     {
       triggerName = "transaction"
       enable = false
       topic = "transaction"
       solidified = false
-      ethCompatible = false // if set true, add transactionIndex, cumulativeEnergyUsed, preCumulativeLogCount, logList, energyUnitPrice, default is false
+      ethCompatible = false // if set true, add transactionIndex, cumulativeEnergyUsed, preCumulativeLogCount, logList, energyUnitPrice. Default: false
     },
     {
-      triggerName = "contractevent"
+      triggerName = "contractevent" // contractevent represents contractlog data decoded by the ABI.
       enable = false
       topic = "contractevent"
     },
@@ -736,7 +809,7 @@ event.subscribe = {
     },
     {
       triggerName = "solidity" // solidity block trigger(just include solidity block number and timestamp), the value can't be modified
-      enable = true            // the default value is true
+      enable = true            // Default: true
       topic = "solidity"
     },
     {

--- a/conf/nile_net_config.conf
+++ b/conf/nile_net_config.conf
@@ -1,80 +1,100 @@
+net {
+  # type is deprecated and has no effect.
+  # type = mainnet
+}
+
 storage {
   # Directory for storing persistent data
-  db.version = 2,
-  db.engine = "LEVELDB",
+  db.engine = "LEVELDB",  // deprecated for arm, because arm only support  "ROCKSDB".
   db.sync = false,
   db.directory = "database",
-  index.directory = "index",
+
+  # Whether to write transaction result in transactionRetStore
   transHistory.switch = "on",
-  # You can custom these 14 databases' configs:
 
-  # account, account-index, asset-issue, block, block-index,
-  # block_KDB, peers, properties, recent-block, trans,
-  # utxo, votes, witness, witness_schedule.
+  # setting can improve leveldb performance .... start, deprecated for arm
+  # node: if this will increase process fds,you may be check your ulimit if 'too many open files' error occurs
+  # see https://github.com/tronprotocol/tips/blob/master/tip-343.md for detail
+  # if you find block sync has lower performance, you can try this settings
+  # default = {
+  #  maxOpenFiles = 100
+  # }
+  # defaultM = {
+  #  maxOpenFiles = 500
+  # }
+  # defaultL = {
+  #  maxOpenFiles = 1000
+  # }
+  # setting can improve leveldb performance .... end, deprecated for arm
 
-  # Otherwise, db configs will remain defualt and data will be stored in
-  # the path of "output-directory" or which is set by "-d" ("--output-directory").
-
-  # Attention: name is a required field that must be set !!!
+  # You can customize the configuration for each database. Otherwise, the database settings will use
+  # their defaults, and data will be stored in the "output-directory" or in the directory specified
+  # by the "-d" or "--output-directory" option. Attention: name is a required field that must be set!
+  # In this configuration, the name and path properties take effect for both LevelDB and RocksDB storage engines,
+  # while the additional properties (such as createIfMissing, paranoidChecks, compressionType, etc.) only take effect when using LevelDB.
   properties = [
-    //    {
-    //      name = "account",
-    //      path = "storage_directory_test",
-    //      createIfMissing = true,
-    //      paranoidChecks = true,
-    //      verifyChecksums = true,
-    //      compressionType = 1,        // compressed with snappy
-    //      blockSize = 4096,           // 4  KB =         4 * 1024 B
-    //      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
-    //      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
-    //      maxOpenFiles = 100
-    //    },
-    //    {
-    //      name = "account-index",
-    //      path = "storage_directory_test",
-    //      createIfMissing = true,
-    //      paranoidChecks = true,
-    //      verifyChecksums = true,
-    //      compressionType = 1,        // compressed with snappy
-    //      blockSize = 4096,           // 4  KB =         4 * 1024 B
-    //      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
-    //      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
-    //      maxOpenFiles = 100
-    //    },
+    #    {
+    #      name = "account",
+    #      path = "storage_directory_test",
+    #      createIfMissing = true, // deprecated for arm start
+    #      paranoidChecks = true,
+    #      verifyChecksums = true,
+    #      compressionType = 1,        // compressed with snappy
+    #      blockSize = 4096,           // 4  KB =         4 * 1024 B
+    #      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
+    #      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
+    #      maxOpenFiles = 100 // deprecated for arm end
+    #    },
+    #    {
+    #      name = "account-index",
+    #      path = "storage_directory_test",
+    #      createIfMissing = true,
+    #      paranoidChecks = true,
+    #      verifyChecksums = true,
+    #      compressionType = 1,        // compressed with snappy
+    #      blockSize = 4096,           // 4  KB =         4 * 1024 B
+    #      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
+    #      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
+    #      maxOpenFiles = 100
+    #    },
   ]
 
   needToUpdateAsset = true
 
-  //dbsettings is needed when using rocksdb as the storage implement (db.version=2 and db.engine="ROCKSDB").
-  //we'd strongly recommend that do not modify it unless you know every item's meaning clearly.
+  # dbsettings is needed when using rocksdb as the storage implement (db.engine="ROCKSDB").
+  # we'd strongly recommend that do not modify it unless you know every item's meaning clearly.
   dbSettings = {
     levelNumber = 7
-    //compactThreads = 32
+    # compactThreads = 32
     blocksize = 64  // n * KB
     maxBytesForLevelBase = 256  // n * MB
     maxBytesForLevelMultiplier = 10
     level0FileNumCompactionTrigger = 4
     targetFileSizeBase = 256  // n * MB
     targetFileSizeMultiplier = 1
+    maxOpenFiles = 5000
   }
 
-  //backup settings when using rocks db as the storage implement (db.version=2 and db.engine="ROCKSDB").
-  //if you want to use the backup plugin, please confirm set the db.version=2 and db.engine="ROCKSDB" above.
-  backup = {
-    enable = false  // indicate whether enable the backup plugin
-    propPath = "prop.properties" // record which bak directory is valid
-    bak1path = "bak1/database" // you must set two backup directories to prevent application halt unexpected(e.g. kill -9).
-    bak2path = "bak2/database"
-    frequency = 10000   // indicate backup db once every 10000 blocks processed.
-  }
+  balance.history.lookup = false
 
-  # if true, transaction cache initialization will be faster. default false
-  # txCache.initOptimization = true
+  # checkpoint.version = 2
+  # checkpoint.sync = true
+
+  # the estimated number of block transactions (default 1000, min 100, max 10000).
+  # so the total number of cached transactions is 65536 * txCache.estimatedTransactions
+  # txCache.estimatedTransactions = 1000
+
+  # if true, transaction cache initialization will be faster. Default: false
+  txCache.initOptimization = true
+
+  # The number of blocks flushed to db in each batch during node syncing. Default: 1
+  # snapshot.maxFlushCount = 1
 
   # data root setting, for check data, currently, only reward-vi is used.
   merkleRoot = {
     reward-vi = b474b61f93824cd70106f8f5283fa740d61b83a7d57a3c12401d627f1fae0a77
   }
+
 }
 
 node.discovery = {
@@ -84,13 +104,22 @@ node.discovery = {
   external.ip = null
 }
 
-
+# custom stop condition
+#node.shutdown = {
+#  BlockTime  = "54 59 08 * * ?" # if block header time in persistent db matched.
+#  BlockHeight = 33350800 # if block header height in persistent db matched.
+#  BlockCount = 12 # block sync count after node start.
+#}
 
 node.backup {
+  # udp listen port, each member should have the same configuration
   port = 10001
 
   # my priority, each member should use different priority
   priority = 8
+
+  # time interval to send keepAlive message, each member should have the same configuration
+  keepAliveInterval = 3000
 
   # peer's ip list, can't contain mine
   members = [
@@ -99,14 +128,27 @@ node.backup {
   ]
 }
 
-# prometheus metrics start
+# Specify the algorithm for generating a public key from private key. To avoid forks, please do not modify it
+crypto {
+  engine = "eckey"
+}
+
 node.metrics = {
-  prometheus{
-    enable=true
-    port="9527"
+  # prometheus metrics
+  prometheus {
+    enable = true
+    port = 9527
+  }
+
+  # influxdb metrics
+  storageEnable = false # Whether write metrics data into InfluxDb. Default: false.
+  influxdb {
+    ip = ""
+    port = 8086
+    database = ""
+    metricsReportInterval = 10
   }
 }
-# prometheus metrics end
 
 node {
   # trust node for solidity node
@@ -120,11 +162,10 @@ node {
 
   connection.timeout = 2
 
-  tcpNettyWorkThreadNum = 0
+  fetchBlock.timeout = 200
+  # syncFetchBatchNum = 2000
 
-  udpNettyWorkThreadNum = 1
-
-  # Number of validate sign thread, default availableProcessors / 2
+  # Number of validate sign thread, default availableProcessors
   # validateSignThreadNum = 16
 
   maxConnections = 30
@@ -133,22 +174,29 @@ node {
 
   minActiveConnections = 3
 
-  maxActiveNodesWithSameIp = 2
+  maxConnectionsWithSameIp = 2
 
   maxHttpConnectNumber = 50
 
   minParticipationRate = 15
 
-  zenTokenId = 1000016
+  # allowShieldedTransactionApi = true
 
-  # check the peer data transfer ,disconnect factor
-  disconnectNumberFactor = 0.4
-  maxConnectNumberFactor = 0.8
-  receiveTcpMinDataLength = 2048
+  # openPrintLog = true
+
+  # If set to true, SR packs transactions into a block in descending order of fee; otherwise, it packs
+  # them based on their receive timestamp. Default: false
+  # openTransactionSort = false
+
+  # The threshold for the number of broadcast transactions received from each peer every second,
+  # transactions exceeding this threshold will be discarded
+  # maxTps = 1000
+
   isOpenFullTcpDisconnect = true
+  inactiveThreshold = 600 //seconds
 
   p2p {
-    version = 201910292
+    version = 201910292 # Mainnet:11111; Nile:201910292; Shasta:1
   }
 
   active = [
@@ -165,40 +213,26 @@ node {
     # "ip:port"
   ]
 
-  # read node.active and node.passive periodically, default false
-  # checkInterval unit: second
-  dynamicConfig {
-    # enable = false
-    # checkInterval = 600
-  }
-
   fastForward = [
   ]
 
   http {
+    fullNodeEnable = true
     fullNodePort = 8090
+    solidityEnable = true
     solidityPort = 8091
-  }
-
-  # use your ipv6 address for node discovery and tcp connection, default false
-  # enableIpv6 = false
-
-  # if your node's highest block num is below than all your pees', try to acquire new connection. default false
-  # effectiveCheckEnable = false
-
-  # Enable node detect
-  # nodeDetectEnable = false
-
-  dns {
-    # dns urls to get nodes, url format tree://{pubkey}@{domain}, default empty
-    treeUrls = [
-      #"tree://APFGGTFOBVE2ZNAB3CSMNNX6RRK3ODIRLP2AA5U4YFAA6MSYZUYTQ@nodes1.example.org",
-    ]
+    PBFTEnable = true
+    PBFTPort = 8092
   }
 
   rpc {
+    enable = true
     port = 50051
-    #solidityPort = 50061
+    solidityEnable = true
+    solidityPort = 50061
+    PBFTEnable = true
+    PBFTPort = 50071
+
     # Number of gRPC thread, default availableProcessors / 2
     # thread = 16
 
@@ -220,17 +254,23 @@ node {
     # The maximum size of header list allowed to be received, default 8192
     # maxHeaderListSize =
 
+    # The number of RST_STREAM frames allowed to be sent per connection per period for grpc, by default there is no limit.
+    # maxRstStream =
+
+    # The number of seconds per period for grpc
+    # secondsPerWindow =
+
     # Transactions can only be broadcast if the number of effective connections is reached.
     minEffectiveConnection = 1
 
-    # The switch of the reflection service, effective for all gRPC services
-    # reflectionService = true
+    # The switch of the reflection service, effective for all gRPC services, used for grpcurl tool. Default: false
+    reflectionService = false
   }
 
   # number of solidity thread in the FullNode.
   # If accessing solidity rpc and http interface timeout, could increase the number of threads,
   # The default value is the number of cpu cores of the machine.
-  #solidity.threads = 8
+  # solidity.threads = 8
 
   # Limits the maximum percentage (default 75%) of producing block interval
   # to provide sufficient time to perform other operations e.g. broadcast block
@@ -239,20 +279,120 @@ node {
   # Limits the maximum number (default 700) of transaction from network layer
   # netMaxTrxPerSecond = 700
 
+  # Whether to enable the node detection function. Default: false
+  # nodeDetectEnable = false
+
+  # use your ipv6 address for node discovery and tcp connection. Default: false
+  # enableIpv6 = false
+
+  # if your node's highest block num is below than all your pees', try to acquire new connection. Default: false
+  # effectiveCheckEnable = false
+
+  # Dynamic loading configuration function, disabled by default
+  dynamicConfig = {
+    # enable = false
+    # checkInterval = 600 // Check interval of Configuration file's change, default is 600 seconds
+  }
+
+  # Whether to continue broadcast transactions after at least maxUnsolidifiedBlocks are not solidified. Default: false
+  # unsolidifiedBlockCheck = false
+  # maxUnsolidifiedBlocks = 54
+
+  dns {
+    # dns urls to get nodes, url format tree://{pubkey}@{domain}, default empty
+    treeUrls = [
+      #"tree://APFGGTFOBVE2ZNAB3CSMNNX6RRK3ODIRLP2AA5U4YFAA6MSYZUYTQ@nodes1.example.org",
+    ]
+
+    # enable or disable dns publish. Default: false
+    # publish = false
+
+    # dns domain to publish nodes, required if publish is true
+    # dnsDomain = "nodes1.example.org"
+
+    # dns private key used to publish, required if publish is true, hex string of length 64
+    # dnsPrivate = "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291"
+
+    # known dns urls to publish if publish is true, url format tree://{pubkey}@{domain}, default empty
+    # knownUrls = [
+    #"tree://APFGGTFOBVE2ZNAB3CSMNNX6RRK3ODIRLP2AA5U4YFAA6MSYZUYTQ@nodes2.example.org",
+    # ]
+
+    # staticNodes = [
+    # static nodes to published on dns
+    # Sample entries:
+    # "ip:port",
+    # "ip:port"
+    # ]
+
+    # merge several nodes into a leaf of tree, should be 1~5
+    # maxMergeSize = 5
+
+    # only nodes change percent is bigger then the threshold, we update data on dns
+    # changeThreshold = 0.1
+
+    # dns server to publish, required if publish is true, only aws or aliyun is support
+    # serverType = "aws"
+
+    # access key id of aws or aliyun api, required if publish is true, string
+    # accessKeyId = "your-key-id"
+
+    # access key secret of aws or aliyun api, required if publish is true, string
+    # accessKeySecret = "your-key-secret"
+
+    # if publish is true and serverType is aliyun, it's endpoint of aws dns server, string
+    # aliyunDnsEndpoint = "alidns.aliyuncs.com"
+
+    # if publish is true and serverType is aws, it's region of aws api, such as "eu-south-1", string
+    # awsRegion = "us-east-1"
+
+    # if publish is true and server-type is aws, it's host zone id of aws's domain, string
+    # awsHostZoneId = "your-host-zone-id"
+  }
+
+  # open the history query APIs(http&GRPC) when node is a lite FullNode,
+  # like {getBlockByNum, getBlockByID, getTransactionByID...}. Default: false.
+  # note: above APIs may return null even if blocks and transactions actually are on the blockchain
+  # when opening on a lite FullNode. only open it if the consequences being clearly known
+  # openHistoryQueryWhenLiteFN = false
+
+  jsonrpc {
+    # Note: Before release_4.8.1, if you turn on jsonrpc and run it for a while and then turn it off,
+    # you will not be able to get the data from eth_getLogs for that period of time. Default: false
+    # httpFullNodeEnable = false
+    # httpFullNodePort = 8545
+    # httpSolidityEnable = false
+    # httpSolidityPort = 8555
+    # httpPBFTEnable = false
+    # httpPBFTPort = 8565
+
+    # The maximum blocks range to retrieve logs for eth_getLogs, default value is 5000,
+    # should be > 0, otherwise means no limit.
+    maxBlockRange = 5000
+
+    # The maximum number of allowed topics within a topic criteria, default value is 1000,
+    # should be > 0, otherwise means no limit.
+    maxSubTopics = 1000
+    # Allowed maximum number for blockFilter
+    maxBlockFilterNum = 50000
+  }
+
+  # Disabled api list, it will work for http, rpc and pbft, both FullNode and SolidityNode,
+  # but not jsonrpc. The setting is case insensitive, GetNowBlock2 is equal to getnowblock2
+  disabledApi = [
+    #  "getaccount",
+    #  "getnowblock2"
+  ]
+
 }
 
 ## rate limiter config
 rate.limiter = {
-  # Use global settings to limit the QPS of the entire node or every ip address
-  # global.qps = 1000
-  # global.ip.qps = 100
-
-  # Every api could be set a specific rate limit strategy. Three strategy are supportedï¼šGlobalPreemptibleAdapterã€IPQPSRateLimiterAdapteã€QpsRateLimiterAdapter
-  # GlobalPreemptibleAdapter: permit is the number of preemptible resource, every client must apply one resourse
-  #       before do the request and release the resource after got the reponse automaticlly. permit should be a Integer.
+  # Every api could only set a specific rate limit strategy. Three blocking strategy are supported:
+  # GlobalPreemptibleAdapter: The number of preemptible resource or maximum concurrent requests globally.
   # QpsRateLimiterAdapter: qps is the average request count in one second supported by the server, it could be a Double or a Integer.
   # IPQPSRateLimiterAdapter: similar to the QpsRateLimiterAdapter, qps could be a Double or a Integer.
-  # If do not set, the "default strategy" is set.The "default startegy" is based on QpsRateLimiterAdapter, the qps is set as 10000.
+  # If not set, QpsRateLimiterAdapter with qps=1000 is the default strategy.
   #
   # Sample entries:
   #
@@ -295,7 +435,19 @@ rate.limiter = {
     #    paramString = "qps=1"
     #  },
   ]
+
+  p2p = {
+    # syncBlockChain = 3.0
+    # fetchInvData = 3.0
+    # disconnect = 1.0
+  }
+
+  # global qps, default 50000
+  global.qps = 50000
+  # IP-based global qps, default 10000
+  global.ip.qps = 10000
 }
+
 
 
 seed.node = {
@@ -482,74 +634,149 @@ genesis.block = {
     }
   ]
 
-  timestamp = "0" #2017-8-26 12:00:00
+  timestamp = "0" # Genesis block timestamp, milli seconds
 
   parentHash = "0xe58f33f9baf9305dc6f82b9f1934ea8f0ade2defb951258d50167028c780351f"
 }
 
-// Optional.The default is empty.
-// It is used when the witness account has set the witnessPermission.
-// When it is not empty, the localWitnessAccountAddress represents the address of the witness account,
-// and the localwitness is configured with the private key of the witnessPermissionAddress in the witness account.
-// When it is empty,the localwitness is configured with the private key of the witness account.
+# Optional. The default is empty. It is used when the witness account has set the witnessPermission.
+# When it is not empty, the localWitnessAccountAddress represents the address of the witness account,
+# and the localwitness is configured with the private key of the witnessPermissionAddress in the witness account.
+# When it is empty,the localwitness is configured with the private key of the witness account.
+# localWitnessAccountAddress =
 
-//localWitnessAccountAddress =
+localwitness = [
+]
 
-#localwitnesskeystore = [
+# localwitnesskeystore = [
 #  "localwitnesskeystore.json"
-#]
+# ]
 
 block = {
   needSyncCheck = false
   maintenanceTimeInterval = 600000
-  proposalExpireTime = 600000 //
+  proposalExpireTime = 600000
+  # checkFrozenTime = 1 // for test only
 }
 
-# Transaction reference block, default is "head", configure to "solid" can avoid TaPos error
-# trx.reference.block = "head" // head;solid;
+# Transaction reference block, default is "solid", configure to "head" may cause TaPos error
+trx.reference.block = "solid" // "head" or "solid"
 
 # This property sets the number of milliseconds after the creation of the transaction that is expired, default value is  60000.
 # trx.expiration.timeInMilliseconds = 60000
 
 vm = {
-  supportConstant =true
+  supportConstant = true
+  maxEnergyLimitForConstant = 100000000
   minTimeRatio = 0.0
   maxTimeRatio = 5.0
   saveInternalTx = true
+  # lruCacheSize = 500
+  # vmTrace = false
+
+  # Indicates whether the node stores featured internal transactions, such as freeze, vote and so on. Default: false.
+  # saveFeaturedInternalTx = false
+
+  # Indicates whether the node stores the details of the internal transactions generated by the CANCELALLUNFREEZEV2 opcode,
+  # such as bandwidth/energy/tronpower cancel amount. Default: false.
+  # saveCancelAllUnfreezeV2Details = false
 
   # In rare cases, transactions that will be within the specified maximum execution time (default 10(ms)) are re-executed and packaged
   # longRunningTime = 10
+
+  # Indicates whether the node support estimate energy API. Default: false.
+  # estimateEnergy = false
+
+  # Indicates the max retry time for executing transaction in estimating energy. Default 3.
+  # estimateEnergyMaxRetry = 3
 }
 
+# These parameters are designed for private chain testing only and cannot be freely switched on or off in production systems.
 committee = {
-  allowCreationOfContracts = 0  //Mainnet:0 (reset by committee),test:1
-  allowAdaptiveEnergy = 0  //Mainnet:0 (reset by committee),test:1
+  allowCreationOfContracts = 0  //mainnet:0 (reset by committee),test:1
+  allowAdaptiveEnergy = 0  //mainnet:0 (reset by committee),test:1
+  # allowCreationOfContracts = 0
+  # allowMultiSign = 0
+  # allowAdaptiveEnergy = 0
+  # allowDelegateResource = 0
+  # allowSameTokenName = 0
+  # allowTvmTransferTrc10 = 0
+  # allowTvmConstantinople = 0
+  # allowTvmSolidity059 = 0
+  # forbidTransferToContract = 0
+  # allowShieldedTRC20Transaction = 0
+  # allowTvmIstanbul = 0
+  # allowMarketTransaction = 0
+  # allowProtoFilterNum = 0
+  # allowAccountStateRoot = 0
+  # changedDelegation = 0
+  # allowPBFT = 0
+  # pBFTExpireNum = 0
+  # allowTransactionFeePool = 0
+  # allowBlackHoleOptimization = 0
+  # allowNewResourceModel = 0
+  # allowReceiptsMerkleRoot = 0
+  # allowTvmFreeze = 0
+  # allowTvmVote = 0
+  # unfreezeDelayDays = 0
+  # allowTvmLondon = 0
+  # allowTvmCompatibleEvm = 0
+  # allowNewRewardAlgorithm = 0
+  # allowAccountAssetOptimization = 0
+  # allowAssetOptimization = 0
+  # allowNewReward = 0
+  # memoFee = 0
+  # allowDelegateOptimization = 0
+  # allowDynamicEnergy = 0
+  # dynamicEnergyThreshold = 0
+  # dynamicEnergyMaxFactor = 0
+  # allowTvmShangHai = 0
+  # allowOldRewardOpt = 0
+  # allowEnergyAdjustment = 0
+  # allowStrictMath = 0
+  # allowTvmCancun = 0
+  # allowTvmBlob = 0
+  # consensusLogicOptimization = 0
+  # allowOptimizedReturnValueOfChainId = 0
+  # allowTvmOsaka = 0
 }
 
 event.subscribe = {
+  enable = false // enable event subscribe, replaces deprecated CLI flag --es
   native = {
     useNativeQueue = true // if true, use native message queue, else use event plugin.
     bindport = 5555 // bind port
     sendqueuelength = 1000 //max length of send queue
   }
+  version = 0
+  # Specify the starting block number to sync historical events. This is only applicable when version = 1.
+  # After performing a full event sync, set this value to 0 or a negative number.
+  # startSyncBlockNum = 1
 
   path = "" // absolute path of plugin
   server = "" // target server address to receive event triggers
-  dbconfig = "" // dbname|username|password
-  contractParse = true,
+  # dbname|username|password, if you want to create indexes for collections when the collections
+  # are not exist, you can add version and set it to 2, as dbname|username|password|version
+  # if you use version 2 and one collection not exists, it will create index automaticaly;
+  # if you use version 2 and one collection exists, it will not create index, you must create index manually;
+  dbconfig = ""
+  contractParse = true
   topics = [
     {
       triggerName = "block" // block trigger, the value can't be modified
       enable = false
       topic = "block" // plugin topic, the value could be modified
+      solidified = false // if set true, just need solidified block. Default: false
     },
     {
       triggerName = "transaction"
       enable = false
       topic = "transaction"
+      solidified = false
+      ethCompatible = false // if set true, add transactionIndex, cumulativeEnergyUsed, preCumulativeLogCount, logList, energyUnitPrice. Default: false
     },
     {
-      triggerName = "contractevent"
+      triggerName = "contractevent" // contractevent represents contractlog data decoded by the ABI.
       enable = false
       topic = "contractevent"
     },
@@ -557,6 +784,23 @@ event.subscribe = {
       triggerName = "contractlog"
       enable = false
       topic = "contractlog"
+      redundancy = false // if set true, contractevent will also be regarded as contractlog
+    },
+    {
+      triggerName = "solidity" // solidity block trigger(just include solidity block number and timestamp), the value can't be modified
+      enable = true            // Default: true
+      topic = "solidity"
+    },
+    {
+      triggerName = "solidityevent"
+      enable = false
+      topic = "solidityevent"
+    },
+    {
+      triggerName = "soliditylog"
+      enable = false
+      topic = "soliditylog"
+      redundancy = false // if set true, solidityevent will also be regarded as soliditylog
     }
   ]
 

--- a/conf/private_net_config_others.conf
+++ b/conf/private_net_config_others.conf
@@ -1,66 +1,151 @@
+net {
+  # type is deprecated and has no effect.
+  # type = mainnet
+}
+
 storage {
   # Directory for storing persistent data
-
-  db.version = 2,
-  db.engine = "LEVELDB",
+  db.engine = "LEVELDB",  // deprecated for arm, because arm only support  "ROCKSDB".
+  db.sync = false,
   db.directory = "database",
-  index.directory = "index",
 
-  # You can custom these 14 databases' configs:
+  # Whether to write transaction result in transactionRetStore
+  transHistory.switch = "on",
 
-  # account, account-index, asset-issue, block, block-index,
-  # block_KDB, peers, properties, recent-block, trans,
-  # utxo, votes, witness, witness_schedule.
+  # setting can improve leveldb performance .... start, deprecated for arm
+  # node: if this will increase process fds,you may be check your ulimit if 'too many open files' error occurs
+  # see https://github.com/tronprotocol/tips/blob/master/tip-343.md for detail
+  # if you find block sync has lower performance, you can try this settings
+  # default = {
+  #  maxOpenFiles = 100
+  # }
+  # defaultM = {
+  #  maxOpenFiles = 500
+  # }
+  # defaultL = {
+  #  maxOpenFiles = 1000
+  # }
+  # setting can improve leveldb performance .... end, deprecated for arm
 
-  # Otherwise, db configs will remain defualt and data will be stored in
-  # the path of "output-directory" or which is set by "-d" ("--output-directory").
-
-  # Attention: name is a required field that must be set !!!
+  # You can customize the configuration for each database. Otherwise, the database settings will use
+  # their defaults, and data will be stored in the "output-directory" or in the directory specified
+  # by the "-d" or "--output-directory" option. Attention: name is a required field that must be set!
+  # In this configuration, the name and path properties take effect for both LevelDB and RocksDB storage engines,
+  # while the additional properties (such as createIfMissing, paranoidChecks, compressionType, etc.) only take effect when using LevelDB.
   properties = [
-    //    {
-    //      name = "account",
-    //      path = "storage_directory_test",
-    //      createIfMissing = true,
-    //      paranoidChecks = true,
-    //      verifyChecksums = true,
-    //      compressionType = 1,        // compressed with snappy
-    //      blockSize = 4096,           // 4  KB =         4 * 1024 B
-    //      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
-    //      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
-    //      maxOpenFiles = 100
-    //    },
-    //    {
-    //      name = "account-index",
-    //      path = "storage_directory_test",
-    //      createIfMissing = true,
-    //      paranoidChecks = true,
-    //      verifyChecksums = true,
-    //      compressionType = 1,        // compressed with snappy
-    //      blockSize = 4096,           // 4  KB =         4 * 1024 B
-    //      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
-    //      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
-    //      maxOpenFiles = 100
-    //    },
+    #    {
+    #      name = "account",
+    #      path = "storage_directory_test",
+    #      createIfMissing = true, // deprecated for arm start
+    #      paranoidChecks = true,
+    #      verifyChecksums = true,
+    #      compressionType = 1,        // compressed with snappy
+    #      blockSize = 4096,           // 4  KB =         4 * 1024 B
+    #      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
+    #      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
+    #      maxOpenFiles = 100 // deprecated for arm end
+    #    },
+    #    {
+    #      name = "account-index",
+    #      path = "storage_directory_test",
+    #      createIfMissing = true,
+    #      paranoidChecks = true,
+    #      verifyChecksums = true,
+    #      compressionType = 1,        // compressed with snappy
+    #      blockSize = 4096,           // 4  KB =         4 * 1024 B
+    #      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
+    #      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
+    #      maxOpenFiles = 100
+    #    },
   ]
-  # data root setting, for check data, currently, only reward-vi is used.
 
+  needToUpdateAsset = true
+
+  # dbsettings is needed when using rocksdb as the storage implement (db.engine="ROCKSDB").
+  # we'd strongly recommend that do not modify it unless you know every item's meaning clearly.
+  dbSettings = {
+    levelNumber = 7
+    # compactThreads = 32
+    blocksize = 64  // n * KB
+    maxBytesForLevelBase = 256  // n * MB
+    maxBytesForLevelMultiplier = 10
+    level0FileNumCompactionTrigger = 4
+    targetFileSizeBase = 256  // n * MB
+    targetFileSizeMultiplier = 1
+    maxOpenFiles = 5000
+  }
+
+  balance.history.lookup = false
+
+  # checkpoint.version = 2
+  # checkpoint.sync = true
+
+  # the estimated number of block transactions (default 1000, min 100, max 10000).
+  # so the total number of cached transactions is 65536 * txCache.estimatedTransactions
+  # txCache.estimatedTransactions = 1000
+
+  # if true, transaction cache initialization will be faster. Default: false
+  txCache.initOptimization = true
+
+  # The number of blocks flushed to db in each batch during node syncing. Default: 1
+  # snapshot.maxFlushCount = 1
+
+  # data root setting, for check data, currently, only reward-vi is used.
   # merkleRoot = {
   # reward-vi = 9debcb9924055500aaae98cdee10501c5c39d4daa75800a996f4bdda73dbccd8 // main-net, Sha256Hash, hexString
   # }
+
 }
 
-# this part of config is used to node discovery.
 node.discovery = {
-  enable = true  # you should set this entry value with true if you want to discover other nodes or be discovered by other nodes.
-  persist = true  # this entry is used to determined to whether storing the peers in the database or not.
+  enable = true
+  persist = true
 }
 
-# this part of config is used to set backup node for witness service.
+# custom stop condition
+#node.shutdown = {
+#  BlockTime  = "54 59 08 * * ?" # if block header time in persistent db matched.
+#  BlockHeight = 33350800 # if block header height in persistent db matched.
+#  BlockCount = 12 # block sync count after node start.
+#}
+
 node.backup {
+  # udp listen port, each member should have the same configuration
   port = 10001
+
+  # my priority, each member should use different priority
   priority = 8
+
+  # time interval to send keepAlive message, each member should have the same configuration
+  keepAliveInterval = 3000
+
+  # peer's ip list, can't contain mine
   members = [
+    # "ip",
+    # "ip"
   ]
+}
+
+# Specify the algorithm for generating a public key from private key. To avoid forks, please do not modify it
+crypto {
+  engine = "eckey"
+}
+
+node.metrics = {
+  # prometheus metrics
+  prometheus {
+    enable = true
+    port = 9527
+  }
+
+  # influxdb metrics
+  storageEnable = false # Whether write metrics data into InfluxDb. Default: false.
+  influxdb {
+    ip = ""
+    port = 8086
+    database = ""
+    metricsReportInterval = 10
+  }
 }
 
 node {
@@ -71,36 +156,49 @@ node {
   # expose extension api to public or not
   walletExtensionApi = true
 
-  # p2p nodes discovery port
   listen.port = 18888
 
   connection.timeout = 2
 
-  tcpNettyWorkThreadNum = 0
+  fetchBlock.timeout = 200
+  # syncFetchBatchNum = 2000
 
-  udpNettyWorkThreadNum = 1
-
-  # Number of validate sign thread, default availableProcessors / 2
+  # Number of validate sign thread, default availableProcessors
   # validateSignThreadNum = 16
 
-  maxActiveNodes = 30
+  maxConnections = 30
 
-  maxActiveNodesWithSameIp = 2
+  minConnections = 8
+
+  minActiveConnections = 3
+
+  maxConnectionsWithSameIp = 2
+
+  maxHttpConnectNumber = 50
 
   minParticipationRate = 0
 
-  # check the peer data transfer ,disconnect factor
-  disconnectNumberFactor = 0.4
-  maxConnectNumberFactor = 0.8
-  receiveTcpMinDataLength = 2048
-  isOpenFullTcpDisconnect = true
+  # allowShieldedTransactionApi = true
+
+  # openPrintLog = true
+
+  # If set to true, SR packs transactions into a block in descending order of fee; otherwise, it packs
+  # them based on their receive timestamp. Default: false
+  # openTransactionSort = false
+
+  # The threshold for the number of broadcast transactions received from each peer every second,
+  # transactions exceeding this threshold will be discarded
+  # maxTps = 1000
+
+  isOpenFullTcpDisconnect = false
+  inactiveThreshold = 600 //seconds
 
   p2p {
-    version = 1 # mainnet:11111; nile testnet:201910292; other net: customized, should not be equal to 11111 or 201910292.
+    version = 1 # Mainnet:11111; Nile:201910292; Shasta:1
   }
 
   active = [
-    # Active establish connection to sync info with peers
+    # Active establish connection in any case
     # Sample entries:
     # "ip:port",
     # "ip:port"
@@ -113,29 +211,24 @@ node {
     # "ip:port"
   ]
 
+  fastForward = [
+  ]
+
   http {
-    # API http request port, default is 8090
-    fullNodePort = 8090
-
-    # Solidity API http request port, default is 8091
-    solidityPort = 8091
-
-    # The default below settings is true. Set them to false to avoid port conflicts with other nodes on the same host machine, or change fullNodeEnable/solidityPort to different ports for each node.
-    solidityEnable = false
     fullNodeEnable = false
-
-    # HttpApiOnPBFTService will start automatically with default port 8092
+    fullNodePort = 8090
+    solidityEnable = false
+    solidityPort = 8091
+    PBFTEnable = true
     PBFTPort = 8093
   }
 
   rpc {
-    # API rpc request port will start automatically with default 50051
+    enable = true
     port = 50051
-
-    # Solidity API rpc request port will start automatically with default port 50061
+    solidityEnable = true
     solidityPort = 50061
-
-    # RpcApiServiceOnPBFT will start automatically with default port 50071
+    PBFTEnable = true
     PBFTPort = 50071
 
     # Number of gRPC thread, default availableProcessors / 2
@@ -159,32 +252,198 @@ node {
     # The maximum size of header list allowed to be received, default 8192
     # maxHeaderListSize =
 
+    # The number of RST_STREAM frames allowed to be sent per connection per period for grpc, by default there is no limit.
+    # maxRstStream =
+
+    # The number of seconds per period for grpc
+    # secondsPerWindow =
+
     # Transactions can only be broadcast if the number of effective connections is reached.
     minEffectiveConnection = 0
+
+    # The switch of the reflection service, effective for all gRPC services, used for grpcurl tool. Default: false
+    reflectionService = false
   }
 
-  # Whether to enable the node detection function, default false
+  # number of solidity thread in the FullNode.
+  # If accessing solidity rpc and http interface timeout, could increase the number of threads,
+  # The default value is the number of cpu cores of the machine.
+  # solidity.threads = 8
+
+  # Limits the maximum percentage (default 75%) of producing block interval
+  # to provide sufficient time to perform other operations e.g. broadcast block
+  # blockProducedTimeOut = 75
+
+  # Limits the maximum number (default 700) of transaction from network layer
+  # netMaxTrxPerSecond = 700
+
+  # Whether to enable the node detection function. Default: false
   # nodeDetectEnable = false
 
-  # use your ipv6 address for node discovery and tcp connection, default false
+  # use your ipv6 address for node discovery and tcp connection. Default: false
   # enableIpv6 = false
 
-  # if your node's highest block num is below than all your pees', try to acquire new connection. default false
+  # if your node's highest block num is below than all your pees', try to acquire new connection. Default: false
   # effectiveCheckEnable = false
 
   # Dynamic loading configuration function, disabled by default
-  # dynamicConfig = {
+  dynamicConfig = {
     # enable = false
-    # Configuration file change check interval, default is 600 seconds
-    # checkInterval = 600
-  # }
+    # checkInterval = 600 // Check interval of Configuration file's change, default is 600 seconds
+  }
+
+  # Whether to continue broadcast transactions after at least maxUnsolidifiedBlocks are not solidified. Default: false
+  # unsolidifiedBlockCheck = false
+  # maxUnsolidifiedBlocks = 54
 
   dns {
     # dns urls to get nodes, url format tree://{pubkey}@{domain}, default empty
     treeUrls = [
       #"tree://APFGGTFOBVE2ZNAB3CSMNNX6RRK3ODIRLP2AA5U4YFAA6MSYZUYTQ@nodes1.example.org",
     ]
+
+    # enable or disable dns publish. Default: false
+    # publish = false
+
+    # dns domain to publish nodes, required if publish is true
+    # dnsDomain = "nodes1.example.org"
+
+    # dns private key used to publish, required if publish is true, hex string of length 64
+    # dnsPrivate = "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291"
+
+    # known dns urls to publish if publish is true, url format tree://{pubkey}@{domain}, default empty
+    # knownUrls = [
+    #"tree://APFGGTFOBVE2ZNAB3CSMNNX6RRK3ODIRLP2AA5U4YFAA6MSYZUYTQ@nodes2.example.org",
+    # ]
+
+    # staticNodes = [
+    # static nodes to published on dns
+    # Sample entries:
+    # "ip:port",
+    # "ip:port"
+    # ]
+
+    # merge several nodes into a leaf of tree, should be 1~5
+    # maxMergeSize = 5
+
+    # only nodes change percent is bigger then the threshold, we update data on dns
+    # changeThreshold = 0.1
+
+    # dns server to publish, required if publish is true, only aws or aliyun is support
+    # serverType = "aws"
+
+    # access key id of aws or aliyun api, required if publish is true, string
+    # accessKeyId = "your-key-id"
+
+    # access key secret of aws or aliyun api, required if publish is true, string
+    # accessKeySecret = "your-key-secret"
+
+    # if publish is true and serverType is aliyun, it's endpoint of aws dns server, string
+    # aliyunDnsEndpoint = "alidns.aliyuncs.com"
+
+    # if publish is true and serverType is aws, it's region of aws api, such as "eu-south-1", string
+    # awsRegion = "us-east-1"
+
+    # if publish is true and server-type is aws, it's host zone id of aws's domain, string
+    # awsHostZoneId = "your-host-zone-id"
   }
+
+  # open the history query APIs(http&GRPC) when node is a lite FullNode,
+  # like {getBlockByNum, getBlockByID, getTransactionByID...}. Default: false.
+  # note: above APIs may return null even if blocks and transactions actually are on the blockchain
+  # when opening on a lite FullNode. only open it if the consequences being clearly known
+  # openHistoryQueryWhenLiteFN = false
+
+  jsonrpc {
+    # Note: Before release_4.8.1, if you turn on jsonrpc and run it for a while and then turn it off,
+    # you will not be able to get the data from eth_getLogs for that period of time. Default: false
+    # httpFullNodeEnable = false
+    # httpFullNodePort = 8545
+    # httpSolidityEnable = false
+    # httpSolidityPort = 8555
+    # httpPBFTEnable = false
+    # httpPBFTPort = 8565
+
+    # The maximum blocks range to retrieve logs for eth_getLogs, default value is 5000,
+    # should be > 0, otherwise means no limit.
+    maxBlockRange = 5000
+
+    # The maximum number of allowed topics within a topic criteria, default value is 1000,
+    # should be > 0, otherwise means no limit.
+    maxSubTopics = 1000
+    # Allowed maximum number for blockFilter
+    maxBlockFilterNum = 50000
+  }
+
+  # Disabled api list, it will work for http, rpc and pbft, both FullNode and SolidityNode,
+  # but not jsonrpc. The setting is case insensitive, GetNowBlock2 is equal to getnowblock2
+  disabledApi = [
+    #  "getaccount",
+    #  "getnowblock2"
+  ]
+
+}
+
+## rate limiter config
+rate.limiter = {
+  # Every api could only set a specific rate limit strategy. Three blocking strategy are supported:
+  # GlobalPreemptibleAdapter: The number of preemptible resource or maximum concurrent requests globally.
+  # QpsRateLimiterAdapter: qps is the average request count in one second supported by the server, it could be a Double or a Integer.
+  # IPQPSRateLimiterAdapter: similar to the QpsRateLimiterAdapter, qps could be a Double or a Integer.
+  # If not set, QpsRateLimiterAdapter with qps=1000 is the default strategy.
+  #
+  # Sample entries:
+  #
+  http = [
+    #  {
+    #    component = "GetNowBlockServlet",
+    #    strategy = "GlobalPreemptibleAdapter",
+    #    paramString = "permit=1"
+    #  },
+
+    #  {
+    #    component = "GetAccountServlet",
+    #    strategy = "IPQPSRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  },
+
+    #  {
+    #    component = "ListWitnessesServlet",
+    #    strategy = "QpsRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  }
+  ],
+
+  rpc = [
+    #  {
+    #    component = "protocol.Wallet/GetBlockByLatestNum2",
+    #    strategy = "GlobalPreemptibleAdapter",
+    #    paramString = "permit=1"
+    #  },
+
+    #  {
+    #    component = "protocol.Wallet/GetAccount",
+    #    strategy = "IPQPSRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  },
+
+    #  {
+    #    component = "protocol.Wallet/ListWitnesses",
+    #    strategy = "QpsRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  },
+  ]
+
+  p2p = {
+    # syncBlockChain = 3.0
+    # fetchInvData = 3.0
+    # disconnect = 1.0
+  }
+
+  # global qps, default 50000
+  global.qps = 50000
+  # IP-based global qps, default 10000
+  global.ip.qps = 10000
 }
 
 
@@ -192,7 +451,7 @@ node {
 seed.node = {
   # List of the seed nodes. This is used to enable the node can connect when join one net at first.
   # If you deploy one private net, you must add some "ip:port" here for other node connecting.
-  # Seed nodes are stable full nodes, and the first SuperNode must be inclued in.
+  # Seed nodes are stable full nodes, and the first SuperNode must be included in.
   # example:
   # ip.list = [
   #   "ip:port",
@@ -273,37 +532,187 @@ genesis.block = {
     }
   ]
 
-  timestamp = "0" #2017-8-26 12:00:00
+  timestamp = "0" # Genesis block timestamp, milli seconds
 
   parentHash = "957dc2d350daecc7bb6a38f3938ebde0a0c1cedafe15f0edae4256a2907449f6"
 }
+
+# Optional. The default is empty. It is used when the witness account has set the witnessPermission.
+# When it is not empty, the localWitnessAccountAddress represents the address of the witness account,
+# and the localwitness is configured with the private key of the witnessPermissionAddress in the witness account.
+# When it is empty,the localwitness is configured with the private key of the witness account.
+# localWitnessAccountAddress =
 
 localwitness = [
   # you must enable this value and the witness address are match.
 ]
 
-#localwitnesskeystore = [
-#  "src/main/resources/localwitnesskeystore.json"  # if you do not set the localwitness above, you must set this value.Otherwise,your SuperNode can not produce the block.
-#]
+# localwitnesskeystore = [
+#  "localwitnesskeystore.json"
+# ]
 
 block = {
   needSyncCheck = true # first node : false, other : true. Set true to sync block with trusted node.
+  maintenanceTimeInterval = 21600000 // 6 hours: 21600000(ms)
+  proposalExpireTime = 259200000 // default value: 3 days: 259200000(ms), Note: this value is controlled by committee proposal
+  # checkFrozenTime = 1 // for test only
 }
+
+# Transaction reference block, default is "solid", configure to "head" may cause TaPos error
+trx.reference.block = "solid" // "head" or "solid"
+
+# This property sets the number of milliseconds after the creation of the transaction that is expired, default value is  60000.
+# trx.expiration.timeInMilliseconds = 60000
+
+# energy limit configuration - set to 0 to enable energy model from genesis block
+enery.limit.block.num = 0
 
 vm = {
-# tron smart contract virtual machine config, refer https://developers.tron.network/docs/tvm#differences-from-evm
   supportConstant = true
+  maxEnergyLimitForConstant = 100000000
   minTimeRatio = 0.0
   maxTimeRatio = 5.0
+  saveInternalTx = false
+  # lruCacheSize = 500
+  # vmTrace = false
+
+  # Indicates whether the node stores featured internal transactions, such as freeze, vote and so on. Default: false.
+  # saveFeaturedInternalTx = false
+
+  # Indicates whether the node stores the details of the internal transactions generated by the CANCELALLUNFREEZEV2 opcode,
+  # such as bandwidth/energy/tronpower cancel amount. Default: false.
+  # saveCancelAllUnfreezeV2Details = false
+
+  # In rare cases, transactions that will be within the specified maximum execution time (default 10(ms)) are re-executed and packaged
+  # longRunningTime = 10
+
+  # Indicates whether the node support estimate energy API. Default: false.
+  # estimateEnergy = false
+
+  # Indicates the max retry time for executing transaction in estimating energy. Default 3.
+  # estimateEnergyMaxRetry = 3
 }
 
+# These parameters are designed for private chain testing only and cannot be freely switched on or off in production systems.
 committee = {
   allowCreationOfContracts = 1
+  allowAdaptiveEnergy = 0
   changedDelegation = 1
   allowTvmTransferTrc10 = 1
+  # allowMultiSign = 0
+  # allowDelegateResource = 0
+  # allowSameTokenName = 0
+  # allowTvmConstantinople = 0
+  # allowTvmSolidity059 = 0
+  # forbidTransferToContract = 0
+  # allowShieldedTRC20Transaction = 0
+  # allowTvmIstanbul = 0
+  # allowMarketTransaction = 0
+  # allowProtoFilterNum = 0
+  # allowAccountStateRoot = 0
+  # allowPBFT = 0
+  # pBFTExpireNum = 0
+  # allowTransactionFeePool = 0
+  # allowBlackHoleOptimization = 0
+  # allowNewResourceModel = 0
+  # allowReceiptsMerkleRoot = 0
+  # allowTvmFreeze = 0
+  # allowTvmVote = 0
+  # unfreezeDelayDays = 0
+  # allowTvmLondon = 0
+  # allowTvmCompatibleEvm = 0
+  # allowNewRewardAlgorithm = 0
+  # allowAccountAssetOptimization = 0
+  # allowAssetOptimization = 0
+  # allowNewReward = 0
+  # memoFee = 0
+  # allowDelegateOptimization = 0
+  # allowDynamicEnergy = 0
+  # dynamicEnergyThreshold = 0
+  # dynamicEnergyMaxFactor = 0
+  # allowTvmShangHai = 0
+  # allowOldRewardOpt = 0
+  # allowEnergyAdjustment = 0
+  # allowStrictMath = 0
+  # allowTvmCancun = 0
+  # allowTvmBlob = 0
+  # consensusLogicOptimization = 0
+  # allowOptimizedReturnValueOfChainId = 0
+  # allowTvmOsaka = 0
 }
 
 event.subscribe = {
- # customized config for capture block or transaction info
- # refer https://tronprotocol.github.io/documentation-en/architecture/event/#configure-node for usage
+  enable = false // enable event subscribe, replaces deprecated CLI flag --es
+  native = {
+    useNativeQueue = true // if true, use native message queue, else use event plugin.
+    bindport = 5555 // bind port
+    sendqueuelength = 1000 //max length of send queue
+  }
+  version = 0
+  # Specify the starting block number to sync historical events. This is only applicable when version = 1.
+  # After performing a full event sync, set this value to 0 or a negative number.
+  # startSyncBlockNum = 1
+
+  path = "" // absolute path of plugin
+  server = "" // target server address to receive event triggers
+  # dbname|username|password, if you want to create indexes for collections when the collections
+  # are not exist, you can add version and set it to 2, as dbname|username|password|version
+  # if you use version 2 and one collection not exists, it will create index automaticaly;
+  # if you use version 2 and one collection exists, it will not create index, you must create index manually;
+  dbconfig = ""
+  contractParse = true
+  topics = [
+    {
+      triggerName = "block" // block trigger, the value can't be modified
+      enable = false
+      topic = "block" // plugin topic, the value could be modified
+      solidified = false // if set true, just need solidified block. Default: false
+    },
+    {
+      triggerName = "transaction"
+      enable = false
+      topic = "transaction"
+      solidified = false
+      ethCompatible = false // if set true, add transactionIndex, cumulativeEnergyUsed, preCumulativeLogCount, logList, energyUnitPrice. Default: false
+    },
+    {
+      triggerName = "contractevent" // contractevent represents contractlog data decoded by the ABI.
+      enable = false
+      topic = "contractevent"
+    },
+    {
+      triggerName = "contractlog"
+      enable = false
+      topic = "contractlog"
+      redundancy = false // if set true, contractevent will also be regarded as contractlog
+    },
+    {
+      triggerName = "solidity" // solidity block trigger(just include solidity block number and timestamp), the value can't be modified
+      enable = true            // Default: true
+      topic = "solidity"
+    },
+    {
+      triggerName = "solidityevent"
+      enable = false
+      topic = "solidityevent"
+    },
+    {
+      triggerName = "soliditylog"
+      enable = false
+      topic = "soliditylog"
+      redundancy = false // if set true, solidityevent will also be regarded as soliditylog
+    }
+  ]
+
+  filter = {
+    fromblock = "" // the value could be "", "earliest" or a specified block number as the beginning of the queried range
+    toblock = "" // the value could be "", "latest" or a specified block number as end of the queried range
+    contractAddress = [
+      "" // contract address you want to subscribe, if it's set to "", you will receive contract logs/events with any contract address.
+    ]
+
+    contractTopic = [
+      "" // contract topic you want to subscribe, if it's set to "", you will receive contract logs/events with any contract topic.
+    ]
+  }
 }

--- a/conf/private_net_config_witness1.conf
+++ b/conf/private_net_config_witness1.conf
@@ -1,66 +1,151 @@
+net {
+  # type is deprecated and has no effect.
+  # type = mainnet
+}
+
 storage {
   # Directory for storing persistent data
-
-  db.version = 2,
-  db.engine = "LEVELDB",
+  db.engine = "LEVELDB",  // deprecated for arm, because arm only support  "ROCKSDB".
+  db.sync = false,
   db.directory = "database",
-  index.directory = "index",
 
-  # You can custom these 14 databases' configs:
+  # Whether to write transaction result in transactionRetStore
+  transHistory.switch = "on",
 
-  # account, account-index, asset-issue, block, block-index,
-  # block_KDB, peers, properties, recent-block, trans,
-  # utxo, votes, witness, witness_schedule.
+  # setting can improve leveldb performance .... start, deprecated for arm
+  # node: if this will increase process fds,you may be check your ulimit if 'too many open files' error occurs
+  # see https://github.com/tronprotocol/tips/blob/master/tip-343.md for detail
+  # if you find block sync has lower performance, you can try this settings
+  # default = {
+  #  maxOpenFiles = 100
+  # }
+  # defaultM = {
+  #  maxOpenFiles = 500
+  # }
+  # defaultL = {
+  #  maxOpenFiles = 1000
+  # }
+  # setting can improve leveldb performance .... end, deprecated for arm
 
-  # Otherwise, db configs will remain defualt and data will be stored in
-  # the path of "output-directory" or which is set by "-d" ("--output-directory").
-
-  # Attention: name is a required field that must be set !!!
+  # You can customize the configuration for each database. Otherwise, the database settings will use
+  # their defaults, and data will be stored in the "output-directory" or in the directory specified
+  # by the "-d" or "--output-directory" option. Attention: name is a required field that must be set!
+  # In this configuration, the name and path properties take effect for both LevelDB and RocksDB storage engines,
+  # while the additional properties (such as createIfMissing, paranoidChecks, compressionType, etc.) only take effect when using LevelDB.
   properties = [
-    //    {
-    //      name = "account",
-    //      path = "storage_directory_test",
-    //      createIfMissing = true,
-    //      paranoidChecks = true,
-    //      verifyChecksums = true,
-    //      compressionType = 1,        // compressed with snappy
-    //      blockSize = 4096,           // 4  KB =         4 * 1024 B
-    //      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
-    //      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
-    //      maxOpenFiles = 100
-    //    },
-    //    {
-    //      name = "account-index",
-    //      path = "storage_directory_test",
-    //      createIfMissing = true,
-    //      paranoidChecks = true,
-    //      verifyChecksums = true,
-    //      compressionType = 1,        // compressed with snappy
-    //      blockSize = 4096,           // 4  KB =         4 * 1024 B
-    //      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
-    //      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
-    //      maxOpenFiles = 100
-    //    },
+    #    {
+    #      name = "account",
+    #      path = "storage_directory_test",
+    #      createIfMissing = true, // deprecated for arm start
+    #      paranoidChecks = true,
+    #      verifyChecksums = true,
+    #      compressionType = 1,        // compressed with snappy
+    #      blockSize = 4096,           // 4  KB =         4 * 1024 B
+    #      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
+    #      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
+    #      maxOpenFiles = 100 // deprecated for arm end
+    #    },
+    #    {
+    #      name = "account-index",
+    #      path = "storage_directory_test",
+    #      createIfMissing = true,
+    #      paranoidChecks = true,
+    #      verifyChecksums = true,
+    #      compressionType = 1,        // compressed with snappy
+    #      blockSize = 4096,           // 4  KB =         4 * 1024 B
+    #      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
+    #      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
+    #      maxOpenFiles = 100
+    #    },
   ]
-  # data root setting, for check data, currently, only reward-vi is used.
 
+  needToUpdateAsset = true
+
+  # dbsettings is needed when using rocksdb as the storage implement (db.engine="ROCKSDB").
+  # we'd strongly recommend that do not modify it unless you know every item's meaning clearly.
+  dbSettings = {
+    levelNumber = 7
+    # compactThreads = 32
+    blocksize = 64  // n * KB
+    maxBytesForLevelBase = 256  // n * MB
+    maxBytesForLevelMultiplier = 10
+    level0FileNumCompactionTrigger = 4
+    targetFileSizeBase = 256  // n * MB
+    targetFileSizeMultiplier = 1
+    maxOpenFiles = 5000
+  }
+
+  balance.history.lookup = false
+
+  # checkpoint.version = 2
+  # checkpoint.sync = true
+
+  # the estimated number of block transactions (default 1000, min 100, max 10000).
+  # so the total number of cached transactions is 65536 * txCache.estimatedTransactions
+  # txCache.estimatedTransactions = 1000
+
+  # if true, transaction cache initialization will be faster. Default: false
+  txCache.initOptimization = true
+
+  # The number of blocks flushed to db in each batch during node syncing. Default: 1
+  # snapshot.maxFlushCount = 1
+
+  # data root setting, for check data, currently, only reward-vi is used.
   # merkleRoot = {
   # reward-vi = 9debcb9924055500aaae98cdee10501c5c39d4daa75800a996f4bdda73dbccd8 // main-net, Sha256Hash, hexString
   # }
+
 }
 
-# this part of config is used to node discovery.
 node.discovery = {
-  enable = true  # you should set this entry value with true if you want to discover other nodes or be discovered by other nodes.
-  persist = true  # this entry is used to determined to whether storing the peers in the database or not.
+  enable = true
+  persist = true
 }
 
-# this part of config is used to set backup node for witness service.
+# custom stop condition
+#node.shutdown = {
+#  BlockTime  = "54 59 08 * * ?" # if block header time in persistent db matched.
+#  BlockHeight = 33350800 # if block header height in persistent db matched.
+#  BlockCount = 12 # block sync count after node start.
+#}
+
 node.backup {
+  # udp listen port, each member should have the same configuration
   port = 10001
+
+  # my priority, each member should use different priority
   priority = 8
+
+  # time interval to send keepAlive message, each member should have the same configuration
+  keepAliveInterval = 3000
+
+  # peer's ip list, can't contain mine
   members = [
+    # "ip",
+    # "ip"
   ]
+}
+
+# Specify the algorithm for generating a public key from private key. To avoid forks, please do not modify it
+crypto {
+  engine = "eckey"
+}
+
+node.metrics = {
+  # prometheus metrics
+  prometheus {
+    enable = true
+    port = 9527
+  }
+
+  # influxdb metrics
+  storageEnable = false # Whether write metrics data into InfluxDb. Default: false.
+  influxdb {
+    ip = ""
+    port = 8086
+    database = ""
+    metricsReportInterval = 10
+  }
 }
 
 node {
@@ -71,69 +156,79 @@ node {
   # expose extension api to public or not
   walletExtensionApi = true
 
-  # p2p nodes discovery port
   listen.port = 18888
 
   connection.timeout = 2
 
-  tcpNettyWorkThreadNum = 0
+  fetchBlock.timeout = 200
+  # syncFetchBatchNum = 2000
 
-  udpNettyWorkThreadNum = 1
-
-  # Number of validate sign thread, default availableProcessors / 2
+  # Number of validate sign thread, default availableProcessors
   # validateSignThreadNum = 16
 
-  maxActiveNodes = 30
+  maxConnections = 30
 
-  maxActiveNodesWithSameIp = 2
+  minConnections = 8
+
+  minActiveConnections = 3
+
+  maxConnectionsWithSameIp = 2
+
+  maxHttpConnectNumber = 50
 
   minParticipationRate = 0
 
-  # check the peer data transfer ,disconnect factor
-  disconnectNumberFactor = 0.4
-  maxConnectNumberFactor = 0.8
-  receiveTcpMinDataLength = 2048
-  isOpenFullTcpDisconnect = true
+  # allowShieldedTransactionApi = true
+
+  # openPrintLog = true
+
+  # If set to true, SR packs transactions into a block in descending order of fee; otherwise, it packs
+  # them based on their receive timestamp. Default: false
+  # openTransactionSort = false
+
+  # The threshold for the number of broadcast transactions received from each peer every second,
+  # transactions exceeding this threshold will be discarded
+  # maxTps = 1000
+
+  isOpenFullTcpDisconnect = false
+  inactiveThreshold = 600 //seconds
 
   p2p {
-    version = 1 # mainnet:11111; nile testnet:201910292; other net: customized, should not be equal to 11111 or 201910292.
+    version = 1 # Mainnet:11111; Nile:201910292; Shasta:1
   }
 
   active = [
     # Active establish connection in any case
+    # Sample entries:
     # "ip:port",
+    # "ip:port"
   ]
 
   passive = [
     # Passive accept connection in any case
+    # Sample entries:
+    # "ip:port",
     # "ip:port"
   ]
 
+  fastForward = [
+  ]
+
   http {
-    # API http request port, default is 8090
-    fullNodePort = 8090
-
-    # default is true
     fullNodeEnable = true
-
-    # Solidity API http request port, default is 8091
-    solidityPort = 8091
-
-    # default is true
+    fullNodePort = 8090
     solidityEnable = true
-
-    # HttpApiOnPBFTService will start automatically with default port 8092
+    solidityPort = 8091
+    PBFTEnable = true
     PBFTPort = 8092
   }
 
   rpc {
-    # API rpc request port, default 50051
+    enable = true
     port = 50051
-
-    # Solidity API rpc request port, default port 50061
+    solidityEnable = true
     solidityPort = 50061
-
-    # RpcApiServiceOnPBFT will start automatically with default port 50071
+    PBFTEnable = true
     PBFTPort = 50071
 
     # Number of gRPC thread, default availableProcessors / 2
@@ -157,49 +252,214 @@ node {
     # The maximum size of header list allowed to be received, default 8192
     # maxHeaderListSize =
 
+    # The number of RST_STREAM frames allowed to be sent per connection per period for grpc, by default there is no limit.
+    # maxRstStream =
+
+    # The number of seconds per period for grpc
+    # secondsPerWindow =
+
     # Transactions can only be broadcast if the number of effective connections is reached.
     minEffectiveConnection = 0
+
+    # The switch of the reflection service, effective for all gRPC services, used for grpcurl tool. Default: false
+    reflectionService = false
   }
 
-  # Whether to enable the node detection function, default false
+  # number of solidity thread in the FullNode.
+  # If accessing solidity rpc and http interface timeout, could increase the number of threads,
+  # The default value is the number of cpu cores of the machine.
+  # solidity.threads = 8
+
+  # Limits the maximum percentage (default 75%) of producing block interval
+  # to provide sufficient time to perform other operations e.g. broadcast block
+  # blockProducedTimeOut = 75
+
+  # Limits the maximum number (default 700) of transaction from network layer
+  # netMaxTrxPerSecond = 700
+
+  # Whether to enable the node detection function. Default: false
   # nodeDetectEnable = false
 
-  # use your ipv6 address for node discovery and tcp connection, default false
+  # use your ipv6 address for node discovery and tcp connection. Default: false
   # enableIpv6 = false
 
-  # if your node's highest block num is below than all your pees', try to acquire new connection. default false
+  # if your node's highest block num is below than all your pees', try to acquire new connection. Default: false
   # effectiveCheckEnable = false
 
   # Dynamic loading configuration function, disabled by default
-  # dynamicConfig = {
+  dynamicConfig = {
     # enable = false
-    # Configuration file change check interval, default is 600 seconds
-    # checkInterval = 600
-  # }
+    # checkInterval = 600 // Check interval of Configuration file's change, default is 600 seconds
+  }
+
+  # Whether to continue broadcast transactions after at least maxUnsolidifiedBlocks are not solidified. Default: false
+  # unsolidifiedBlockCheck = false
+  # maxUnsolidifiedBlocks = 54
 
   dns {
     # dns urls to get nodes, url format tree://{pubkey}@{domain}, default empty
     treeUrls = [
       #"tree://APFGGTFOBVE2ZNAB3CSMNNX6RRK3ODIRLP2AA5U4YFAA6MSYZUYTQ@nodes1.example.org",
     ]
+
+    # enable or disable dns publish. Default: false
+    # publish = false
+
+    # dns domain to publish nodes, required if publish is true
+    # dnsDomain = "nodes1.example.org"
+
+    # dns private key used to publish, required if publish is true, hex string of length 64
+    # dnsPrivate = "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291"
+
+    # known dns urls to publish if publish is true, url format tree://{pubkey}@{domain}, default empty
+    # knownUrls = [
+    #"tree://APFGGTFOBVE2ZNAB3CSMNNX6RRK3ODIRLP2AA5U4YFAA6MSYZUYTQ@nodes2.example.org",
+    # ]
+
+    # staticNodes = [
+    # static nodes to published on dns
+    # Sample entries:
+    # "ip:port",
+    # "ip:port"
+    # ]
+
+    # merge several nodes into a leaf of tree, should be 1~5
+    # maxMergeSize = 5
+
+    # only nodes change percent is bigger then the threshold, we update data on dns
+    # changeThreshold = 0.1
+
+    # dns server to publish, required if publish is true, only aws or aliyun is support
+    # serverType = "aws"
+
+    # access key id of aws or aliyun api, required if publish is true, string
+    # accessKeyId = "your-key-id"
+
+    # access key secret of aws or aliyun api, required if publish is true, string
+    # accessKeySecret = "your-key-secret"
+
+    # if publish is true and serverType is aliyun, it's endpoint of aws dns server, string
+    # aliyunDnsEndpoint = "alidns.aliyuncs.com"
+
+    # if publish is true and serverType is aws, it's region of aws api, such as "eu-south-1", string
+    # awsRegion = "us-east-1"
+
+    # if publish is true and server-type is aws, it's host zone id of aws's domain, string
+    # awsHostZoneId = "your-host-zone-id"
   }
+
+  # open the history query APIs(http&GRPC) when node is a lite FullNode,
+  # like {getBlockByNum, getBlockByID, getTransactionByID...}. Default: false.
+  # note: above APIs may return null even if blocks and transactions actually are on the blockchain
+  # when opening on a lite FullNode. only open it if the consequences being clearly known
+  # openHistoryQueryWhenLiteFN = false
+
+  jsonrpc {
+    # Note: Before release_4.8.1, if you turn on jsonrpc and run it for a while and then turn it off,
+    # you will not be able to get the data from eth_getLogs for that period of time. Default: false
+    # httpFullNodeEnable = false
+    # httpFullNodePort = 8545
+    # httpSolidityEnable = false
+    # httpSolidityPort = 8555
+    # httpPBFTEnable = false
+    # httpPBFTPort = 8565
+
+    # The maximum blocks range to retrieve logs for eth_getLogs, default value is 5000,
+    # should be > 0, otherwise means no limit.
+    maxBlockRange = 5000
+
+    # The maximum number of allowed topics within a topic criteria, default value is 1000,
+    # should be > 0, otherwise means no limit.
+    maxSubTopics = 1000
+    # Allowed maximum number for blockFilter
+    maxBlockFilterNum = 50000
+  }
+
+  # Disabled api list, it will work for http, rpc and pbft, both FullNode and SolidityNode,
+  # but not jsonrpc. The setting is case insensitive, GetNowBlock2 is equal to getnowblock2
+  disabledApi = [
+    #  "getaccount",
+    #  "getnowblock2"
+  ]
+
 }
+
+## rate limiter config
+rate.limiter = {
+  # Every api could only set a specific rate limit strategy. Three blocking strategy are supported:
+  # GlobalPreemptibleAdapter: The number of preemptible resource or maximum concurrent requests globally.
+  # QpsRateLimiterAdapter: qps is the average request count in one second supported by the server, it could be a Double or a Integer.
+  # IPQPSRateLimiterAdapter: similar to the QpsRateLimiterAdapter, qps could be a Double or a Integer.
+  # If not set, QpsRateLimiterAdapter with qps=1000 is the default strategy.
+  #
+  # Sample entries:
+  #
+  http = [
+    #  {
+    #    component = "GetNowBlockServlet",
+    #    strategy = "GlobalPreemptibleAdapter",
+    #    paramString = "permit=1"
+    #  },
+
+    #  {
+    #    component = "GetAccountServlet",
+    #    strategy = "IPQPSRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  },
+
+    #  {
+    #    component = "ListWitnessesServlet",
+    #    strategy = "QpsRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  }
+  ],
+
+  rpc = [
+    #  {
+    #    component = "protocol.Wallet/GetBlockByLatestNum2",
+    #    strategy = "GlobalPreemptibleAdapter",
+    #    paramString = "permit=1"
+    #  },
+
+    #  {
+    #    component = "protocol.Wallet/GetAccount",
+    #    strategy = "IPQPSRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  },
+
+    #  {
+    #    component = "protocol.Wallet/ListWitnesses",
+    #    strategy = "QpsRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  },
+  ]
+
+  p2p = {
+    # syncBlockChain = 3.0
+    # fetchInvData = 3.0
+    # disconnect = 1.0
+  }
+
+  # global qps, default 50000
+  global.qps = 50000
+  # IP-based global qps, default 10000
+  global.ip.qps = 10000
+}
+
 
 
 seed.node = {
   # List of the seed nodes. This is used to enable the node can connect when join one net at first.
   # If you deploy one private net, you must add some "ip:port" here for other node connecting.
-  # Seed nodes are stable full nodes, and the first SuperNode must be inclued in.
+  # Seed nodes are stable full nodes, and the first SuperNode must be included in.
   # example:
   # ip.list = [
   #   "ip:port",
-  #   "ip:port"
   # ]
   ip.list = [
   ]
 }
 
-# if you use the fork database from mainnet keep this genesis.block the same as mainnet
 genesis.block = {
   # Reserve balance
   assets = [
@@ -266,38 +526,188 @@ genesis.block = {
     }
   ]
 
-  timestamp = "0" #2017-8-26 12:00:00
+  timestamp = "0" # Genesis block timestamp, milli seconds
 
   parentHash = "957dc2d350daecc7bb6a38f3938ebde0a0c1cedafe15f0edae4256a2907449f6"
 }
 
+# Optional. The default is empty. It is used when the witness account has set the witnessPermission.
+# When it is not empty, the localWitnessAccountAddress represents the address of the witness account,
+# and the localwitness is configured with the private key of the witnessPermissionAddress in the witness account.
+# When it is empty,the localwitness is configured with the private key of the witness account.
+# localWitnessAccountAddress =
+
 localwitness = [
   # address TPL66VK2gCXNCD7EJg9pgJRfqcRazjhUZY
-  da146374a75310b9666e834ee4ad0866d6f4035967bfc76217c5a495fff9f0d0  # you must enable this value and the witness address are match.
+  da146374a75310b9666e834ee4ad0866d6f4035967bfc76217c5a495fff9f0d0
 ]
 
-#localwitnesskeystore = [
-#  "src/main/resources/localwitnesskeystore.json"  # if you do not set the localwitness above, you must set this value.Otherwise,your SuperNode can not produce the block.
-#]
+# localwitnesskeystore = [
+#  "localwitnesskeystore.json"
+# ]
 
 block = {
   needSyncCheck = false # first node : false, other : true
+  maintenanceTimeInterval = 21600000 // 6 hours: 21600000(ms)
+  proposalExpireTime = 259200000 // default value: 3 days: 259200000(ms), Note: this value is controlled by committee proposal
+  # checkFrozenTime = 1 // for test only
 }
+
+# Transaction reference block, default is "solid", configure to "head" may cause TaPos error
+trx.reference.block = "solid" // "head" or "solid"
+
+# This property sets the number of milliseconds after the creation of the transaction that is expired, default value is  60000.
+# trx.expiration.timeInMilliseconds = 60000
+
+# energy limit configuration - set to 0 to enable energy model from genesis block
+enery.limit.block.num = 0
 
 vm = {
-# tron smart contract virtual machine config, refer https://developers.tron.network/docs/tvm#differences-from-evm
   supportConstant = true
+  maxEnergyLimitForConstant = 100000000
   minTimeRatio = 0.0
   maxTimeRatio = 5.0
+  saveInternalTx = false
+  # lruCacheSize = 500
+  # vmTrace = false
+
+  # Indicates whether the node stores featured internal transactions, such as freeze, vote and so on. Default: false.
+  # saveFeaturedInternalTx = false
+
+  # Indicates whether the node stores the details of the internal transactions generated by the CANCELALLUNFREEZEV2 opcode,
+  # such as bandwidth/energy/tronpower cancel amount. Default: false.
+  # saveCancelAllUnfreezeV2Details = false
+
+  # In rare cases, transactions that will be within the specified maximum execution time (default 10(ms)) are re-executed and packaged
+  # longRunningTime = 10
+
+  # Indicates whether the node support estimate energy API. Default: false.
+  # estimateEnergy = false
+
+  # Indicates the max retry time for executing transaction in estimating energy. Default 3.
+  # estimateEnergyMaxRetry = 3
 }
 
+# These parameters are designed for private chain testing only and cannot be freely switched on or off in production systems.
 committee = {
   allowCreationOfContracts = 1
+  allowAdaptiveEnergy = 0
   changedDelegation = 1
   allowTvmTransferTrc10 = 1
+  # allowMultiSign = 0
+  # allowDelegateResource = 0
+  # allowSameTokenName = 0
+  # allowTvmConstantinople = 0
+  # allowTvmSolidity059 = 0
+  # forbidTransferToContract = 0
+  # allowShieldedTRC20Transaction = 0
+  # allowTvmIstanbul = 0
+  # allowMarketTransaction = 0
+  # allowProtoFilterNum = 0
+  # allowAccountStateRoot = 0
+  # allowPBFT = 0
+  # pBFTExpireNum = 0
+  # allowTransactionFeePool = 0
+  # allowBlackHoleOptimization = 0
+  # allowNewResourceModel = 0
+  # allowReceiptsMerkleRoot = 0
+  # allowTvmFreeze = 0
+  # allowTvmVote = 0
+  # unfreezeDelayDays = 0
+  # allowTvmLondon = 0
+  # allowTvmCompatibleEvm = 0
+  # allowNewRewardAlgorithm = 0
+  # allowAccountAssetOptimization = 0
+  # allowAssetOptimization = 0
+  # allowNewReward = 0
+  # memoFee = 0
+  # allowDelegateOptimization = 0
+  # allowDynamicEnergy = 0
+  # dynamicEnergyThreshold = 0
+  # dynamicEnergyMaxFactor = 0
+  # allowTvmShangHai = 0
+  # allowOldRewardOpt = 0
+  # allowEnergyAdjustment = 0
+  # allowStrictMath = 0
+  # allowTvmCancun = 0
+  # allowTvmBlob = 0
+  # consensusLogicOptimization = 0
+  # allowOptimizedReturnValueOfChainId = 0
+  # allowTvmOsaka = 0
 }
 
 event.subscribe = {
- # customized config for capture block or transaction info
- # refer https://tronprotocol.github.io/documentation-en/architecture/event/#configure-node for usage
+  enable = false // enable event subscribe, replaces deprecated CLI flag --es
+  native = {
+    useNativeQueue = true // if true, use native message queue, else use event plugin.
+    bindport = 5555 // bind port
+    sendqueuelength = 1000 //max length of send queue
+  }
+  version = 0
+  # Specify the starting block number to sync historical events. This is only applicable when version = 1.
+  # After performing a full event sync, set this value to 0 or a negative number.
+  # startSyncBlockNum = 1
+
+  path = "" // absolute path of plugin
+  server = "" // target server address to receive event triggers
+  # dbname|username|password, if you want to create indexes for collections when the collections
+  # are not exist, you can add version and set it to 2, as dbname|username|password|version
+  # if you use version 2 and one collection not exists, it will create index automaticaly;
+  # if you use version 2 and one collection exists, it will not create index, you must create index manually;
+  dbconfig = ""
+  contractParse = true
+  topics = [
+    {
+      triggerName = "block" // block trigger, the value can't be modified
+      enable = false
+      topic = "block" // plugin topic, the value could be modified
+      solidified = false // if set true, just need solidified block. Default: false
+    },
+    {
+      triggerName = "transaction"
+      enable = false
+      topic = "transaction"
+      solidified = false
+      ethCompatible = false // if set true, add transactionIndex, cumulativeEnergyUsed, preCumulativeLogCount, logList, energyUnitPrice. Default: false
+    },
+    {
+      triggerName = "contractevent" // contractevent represents contractlog data decoded by the ABI.
+      enable = false
+      topic = "contractevent"
+    },
+    {
+      triggerName = "contractlog"
+      enable = false
+      topic = "contractlog"
+      redundancy = false // if set true, contractevent will also be regarded as contractlog
+    },
+    {
+      triggerName = "solidity" // solidity block trigger(just include solidity block number and timestamp), the value can't be modified
+      enable = true            // Default: true
+      topic = "solidity"
+    },
+    {
+      triggerName = "solidityevent"
+      enable = false
+      topic = "solidityevent"
+    },
+    {
+      triggerName = "soliditylog"
+      enable = false
+      topic = "soliditylog"
+      redundancy = false // if set true, solidityevent will also be regarded as soliditylog
+    }
+  ]
+
+  filter = {
+    fromblock = "" // the value could be "", "earliest" or a specified block number as the beginning of the queried range
+    toblock = "" // the value could be "", "latest" or a specified block number as end of the queried range
+    contractAddress = [
+      "" // contract address you want to subscribe, if it's set to "", you will receive contract logs/events with any contract address.
+    ]
+
+    contractTopic = [
+      "" // contract topic you want to subscribe, if it's set to "", you will receive contract logs/events with any contract topic.
+    ]
+  }
 }

--- a/conf/private_net_config_witness2.conf
+++ b/conf/private_net_config_witness2.conf
@@ -1,66 +1,151 @@
+net {
+  # type is deprecated and has no effect.
+  # type = mainnet
+}
+
 storage {
   # Directory for storing persistent data
-
-  db.version = 2,
-  db.engine = "LEVELDB",
+  db.engine = "LEVELDB",  // deprecated for arm, because arm only support  "ROCKSDB".
+  db.sync = false,
   db.directory = "database",
-  index.directory = "index",
 
-  # You can custom these 14 databases' configs:
+  # Whether to write transaction result in transactionRetStore
+  transHistory.switch = "on",
 
-  # account, account-index, asset-issue, block, block-index,
-  # block_KDB, peers, properties, recent-block, trans,
-  # utxo, votes, witness, witness_schedule.
+  # setting can improve leveldb performance .... start, deprecated for arm
+  # node: if this will increase process fds,you may be check your ulimit if 'too many open files' error occurs
+  # see https://github.com/tronprotocol/tips/blob/master/tip-343.md for detail
+  # if you find block sync has lower performance, you can try this settings
+  # default = {
+  #  maxOpenFiles = 100
+  # }
+  # defaultM = {
+  #  maxOpenFiles = 500
+  # }
+  # defaultL = {
+  #  maxOpenFiles = 1000
+  # }
+  # setting can improve leveldb performance .... end, deprecated for arm
 
-  # Otherwise, db configs will remain defualt and data will be stored in
-  # the path of "output-directory" or which is set by "-d" ("--output-directory").
-
-  # Attention: name is a required field that must be set !!!
+  # You can customize the configuration for each database. Otherwise, the database settings will use
+  # their defaults, and data will be stored in the "output-directory" or in the directory specified
+  # by the "-d" or "--output-directory" option. Attention: name is a required field that must be set!
+  # In this configuration, the name and path properties take effect for both LevelDB and RocksDB storage engines,
+  # while the additional properties (such as createIfMissing, paranoidChecks, compressionType, etc.) only take effect when using LevelDB.
   properties = [
-    //    {
-    //      name = "account",
-    //      path = "storage_directory_test",
-    //      createIfMissing = true,
-    //      paranoidChecks = true,
-    //      verifyChecksums = true,
-    //      compressionType = 1,        // compressed with snappy
-    //      blockSize = 4096,           // 4  KB =         4 * 1024 B
-    //      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
-    //      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
-    //      maxOpenFiles = 100
-    //    },
-    //    {
-    //      name = "account-index",
-    //      path = "storage_directory_test",
-    //      createIfMissing = true,
-    //      paranoidChecks = true,
-    //      verifyChecksums = true,
-    //      compressionType = 1,        // compressed with snappy
-    //      blockSize = 4096,           // 4  KB =         4 * 1024 B
-    //      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
-    //      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
-    //      maxOpenFiles = 100
-    //    },
+    #    {
+    #      name = "account",
+    #      path = "storage_directory_test",
+    #      createIfMissing = true, // deprecated for arm start
+    #      paranoidChecks = true,
+    #      verifyChecksums = true,
+    #      compressionType = 1,        // compressed with snappy
+    #      blockSize = 4096,           // 4  KB =         4 * 1024 B
+    #      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
+    #      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
+    #      maxOpenFiles = 100 // deprecated for arm end
+    #    },
+    #    {
+    #      name = "account-index",
+    #      path = "storage_directory_test",
+    #      createIfMissing = true,
+    #      paranoidChecks = true,
+    #      verifyChecksums = true,
+    #      compressionType = 1,        // compressed with snappy
+    #      blockSize = 4096,           // 4  KB =         4 * 1024 B
+    #      writeBufferSize = 10485760, // 10 MB = 10 * 1024 * 1024 B
+    #      cacheSize = 10485760,       // 10 MB = 10 * 1024 * 1024 B
+    #      maxOpenFiles = 100
+    #    },
   ]
-  # data root setting, for check data, currently, only reward-vi is used.
 
+  needToUpdateAsset = true
+
+  # dbsettings is needed when using rocksdb as the storage implement (db.engine="ROCKSDB").
+  # we'd strongly recommend that do not modify it unless you know every item's meaning clearly.
+  dbSettings = {
+    levelNumber = 7
+    # compactThreads = 32
+    blocksize = 64  // n * KB
+    maxBytesForLevelBase = 256  // n * MB
+    maxBytesForLevelMultiplier = 10
+    level0FileNumCompactionTrigger = 4
+    targetFileSizeBase = 256  // n * MB
+    targetFileSizeMultiplier = 1
+    maxOpenFiles = 5000
+  }
+
+  balance.history.lookup = false
+
+  # checkpoint.version = 2
+  # checkpoint.sync = true
+
+  # the estimated number of block transactions (default 1000, min 100, max 10000).
+  # so the total number of cached transactions is 65536 * txCache.estimatedTransactions
+  # txCache.estimatedTransactions = 1000
+
+  # if true, transaction cache initialization will be faster. Default: false
+  txCache.initOptimization = true
+
+  # The number of blocks flushed to db in each batch during node syncing. Default: 1
+  # snapshot.maxFlushCount = 1
+
+  # data root setting, for check data, currently, only reward-vi is used.
   # merkleRoot = {
   # reward-vi = 9debcb9924055500aaae98cdee10501c5c39d4daa75800a996f4bdda73dbccd8 // main-net, Sha256Hash, hexString
   # }
+
 }
 
-# this part of config is used to node discovery.
 node.discovery = {
-  enable = true  # you should set this entry value with true if you want to discover other nodes or be discovered by other nodes.
-  persist = true  # this entry is used to determined to whether storing the peers in the database or not.
+  enable = true
+  persist = true
 }
 
-# this part of config is used to set backup node for witness service.
+# custom stop condition
+#node.shutdown = {
+#  BlockTime  = "54 59 08 * * ?" # if block header time in persistent db matched.
+#  BlockHeight = 33350800 # if block header height in persistent db matched.
+#  BlockCount = 12 # block sync count after node start.
+#}
+
 node.backup {
+  # udp listen port, each member should have the same configuration
   port = 10001
+
+  # my priority, each member should use different priority
   priority = 8
+
+  # time interval to send keepAlive message, each member should have the same configuration
+  keepAliveInterval = 3000
+
+  # peer's ip list, can't contain mine
   members = [
+    # "ip",
+    # "ip"
   ]
+}
+
+# Specify the algorithm for generating a public key from private key. To avoid forks, please do not modify it
+crypto {
+  engine = "eckey"
+}
+
+node.metrics = {
+  # prometheus metrics
+  prometheus {
+    enable = true
+    port = 9527
+  }
+
+  # influxdb metrics
+  storageEnable = false # Whether write metrics data into InfluxDb. Default: false.
+  influxdb {
+    ip = ""
+    port = 8086
+    database = ""
+    metricsReportInterval = 10
+  }
 }
 
 node {
@@ -71,69 +156,79 @@ node {
   # expose extension api to public or not
   walletExtensionApi = true
 
-  # p2p nodes discovery port
   listen.port = 18888
 
   connection.timeout = 2
 
-  tcpNettyWorkThreadNum = 0
+  fetchBlock.timeout = 200
+  # syncFetchBatchNum = 2000
 
-  udpNettyWorkThreadNum = 1
-
-  # Number of validate sign thread, default availableProcessors / 2
+  # Number of validate sign thread, default availableProcessors
   # validateSignThreadNum = 16
 
-  maxActiveNodes = 30
+  maxConnections = 30
 
-  maxActiveNodesWithSameIp = 2
+  minConnections = 8
+
+  minActiveConnections = 3
+
+  maxConnectionsWithSameIp = 2
+
+  maxHttpConnectNumber = 50
 
   minParticipationRate = 0
 
-  # check the peer data transfer ,disconnect factor
-  disconnectNumberFactor = 0.4
-  maxConnectNumberFactor = 0.8
-  receiveTcpMinDataLength = 2048
-  isOpenFullTcpDisconnect = true
+  # allowShieldedTransactionApi = true
+
+  # openPrintLog = true
+
+  # If set to true, SR packs transactions into a block in descending order of fee; otherwise, it packs
+  # them based on their receive timestamp. Default: false
+  # openTransactionSort = false
+
+  # The threshold for the number of broadcast transactions received from each peer every second,
+  # transactions exceeding this threshold will be discarded
+  # maxTps = 1000
+
+  isOpenFullTcpDisconnect = false
+  inactiveThreshold = 600 //seconds
 
   p2p {
-    version = 1 # mainnet:11111; nile testnet:201910292; other net: customized, should not be equal to 11111 or 201910292.
+    version = 1 # Mainnet:11111; Nile:201910292; Shasta:1
   }
 
   active = [
     # Active establish connection in any case
+    # Sample entries:
     # "ip:port",
+    # "ip:port"
   ]
 
   passive = [
     # Passive accept connection in any case
+    # Sample entries:
+    # "ip:port",
     # "ip:port"
   ]
 
+  fastForward = [
+  ]
+
   http {
-    # API http request port, default is 8090
-    fullNodePort = 8090
-
-    # default is true
     fullNodeEnable = true
-
-    # Solidity API http request port, default is 8091
-    solidityPort = 8091
-
-    # default is true
+    fullNodePort = 8090
     solidityEnable = true
-
-    # HttpApiOnPBFTService will start automatically with default port 8092
+    solidityPort = 8091
+    PBFTEnable = true
     PBFTPort = 8092
   }
 
   rpc {
-    # API rpc request port, default 50051
+    enable = true
     port = 50051
-
-    # Solidity API rpc request port, default port 50061
+    solidityEnable = true
     solidityPort = 50061
-
-    # RpcApiServiceOnPBFT will start automatically with default port 50071
+    PBFTEnable = true
     PBFTPort = 50071
 
     # Number of gRPC thread, default availableProcessors / 2
@@ -157,50 +252,215 @@ node {
     # The maximum size of header list allowed to be received, default 8192
     # maxHeaderListSize =
 
+    # The number of RST_STREAM frames allowed to be sent per connection per period for grpc, by default there is no limit.
+    # maxRstStream =
+
+    # The number of seconds per period for grpc
+    # secondsPerWindow =
+
     # Transactions can only be broadcast if the number of effective connections is reached.
     minEffectiveConnection = 0
+
+    # The switch of the reflection service, effective for all gRPC services, used for grpcurl tool. Default: false
+    reflectionService = false
   }
 
-  # Whether to enable the node detection function, default false
+  # number of solidity thread in the FullNode.
+  # If accessing solidity rpc and http interface timeout, could increase the number of threads,
+  # The default value is the number of cpu cores of the machine.
+  # solidity.threads = 8
+
+  # Limits the maximum percentage (default 75%) of producing block interval
+  # to provide sufficient time to perform other operations e.g. broadcast block
+  # blockProducedTimeOut = 75
+
+  # Limits the maximum number (default 700) of transaction from network layer
+  # netMaxTrxPerSecond = 700
+
+  # Whether to enable the node detection function. Default: false
   # nodeDetectEnable = false
 
-  # use your ipv6 address for node discovery and tcp connection, default false
+  # use your ipv6 address for node discovery and tcp connection. Default: false
   # enableIpv6 = false
 
-  # if your node's highest block num is below than all your pees', try to acquire new connection. default false
+  # if your node's highest block num is below than all your pees', try to acquire new connection. Default: false
   # effectiveCheckEnable = false
 
   # Dynamic loading configuration function, disabled by default
-  # dynamicConfig = {
+  dynamicConfig = {
     # enable = false
-    # Configuration file change check interval, default is 600 seconds
-    # checkInterval = 600
-  # }
+    # checkInterval = 600 // Check interval of Configuration file's change, default is 600 seconds
+  }
+
+  # Whether to continue broadcast transactions after at least maxUnsolidifiedBlocks are not solidified. Default: false
+  # unsolidifiedBlockCheck = false
+  # maxUnsolidifiedBlocks = 54
 
   dns {
     # dns urls to get nodes, url format tree://{pubkey}@{domain}, default empty
     treeUrls = [
       #"tree://APFGGTFOBVE2ZNAB3CSMNNX6RRK3ODIRLP2AA5U4YFAA6MSYZUYTQ@nodes1.example.org",
     ]
+
+    # enable or disable dns publish. Default: false
+    # publish = false
+
+    # dns domain to publish nodes, required if publish is true
+    # dnsDomain = "nodes1.example.org"
+
+    # dns private key used to publish, required if publish is true, hex string of length 64
+    # dnsPrivate = "b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291"
+
+    # known dns urls to publish if publish is true, url format tree://{pubkey}@{domain}, default empty
+    # knownUrls = [
+    #"tree://APFGGTFOBVE2ZNAB3CSMNNX6RRK3ODIRLP2AA5U4YFAA6MSYZUYTQ@nodes2.example.org",
+    # ]
+
+    # staticNodes = [
+    # static nodes to published on dns
+    # Sample entries:
+    # "ip:port",
+    # "ip:port"
+    # ]
+
+    # merge several nodes into a leaf of tree, should be 1~5
+    # maxMergeSize = 5
+
+    # only nodes change percent is bigger then the threshold, we update data on dns
+    # changeThreshold = 0.1
+
+    # dns server to publish, required if publish is true, only aws or aliyun is support
+    # serverType = "aws"
+
+    # access key id of aws or aliyun api, required if publish is true, string
+    # accessKeyId = "your-key-id"
+
+    # access key secret of aws or aliyun api, required if publish is true, string
+    # accessKeySecret = "your-key-secret"
+
+    # if publish is true and serverType is aliyun, it's endpoint of aws dns server, string
+    # aliyunDnsEndpoint = "alidns.aliyuncs.com"
+
+    # if publish is true and serverType is aws, it's region of aws api, such as "eu-south-1", string
+    # awsRegion = "us-east-1"
+
+    # if publish is true and server-type is aws, it's host zone id of aws's domain, string
+    # awsHostZoneId = "your-host-zone-id"
   }
+
+  # open the history query APIs(http&GRPC) when node is a lite FullNode,
+  # like {getBlockByNum, getBlockByID, getTransactionByID...}. Default: false.
+  # note: above APIs may return null even if blocks and transactions actually are on the blockchain
+  # when opening on a lite FullNode. only open it if the consequences being clearly known
+  # openHistoryQueryWhenLiteFN = false
+
+  jsonrpc {
+    # Note: Before release_4.8.1, if you turn on jsonrpc and run it for a while and then turn it off,
+    # you will not be able to get the data from eth_getLogs for that period of time. Default: false
+    # httpFullNodeEnable = false
+    # httpFullNodePort = 8545
+    # httpSolidityEnable = false
+    # httpSolidityPort = 8555
+    # httpPBFTEnable = false
+    # httpPBFTPort = 8565
+
+    # The maximum blocks range to retrieve logs for eth_getLogs, default value is 5000,
+    # should be > 0, otherwise means no limit.
+    maxBlockRange = 5000
+
+    # The maximum number of allowed topics within a topic criteria, default value is 1000,
+    # should be > 0, otherwise means no limit.
+    maxSubTopics = 1000
+    # Allowed maximum number for blockFilter
+    maxBlockFilterNum = 50000
+  }
+
+  # Disabled api list, it will work for http, rpc and pbft, both FullNode and SolidityNode,
+  # but not jsonrpc. The setting is case insensitive, GetNowBlock2 is equal to getnowblock2
+  disabledApi = [
+    #  "getaccount",
+    #  "getnowblock2"
+  ]
+
 }
+
+## rate limiter config
+rate.limiter = {
+  # Every api could only set a specific rate limit strategy. Three blocking strategy are supported:
+  # GlobalPreemptibleAdapter: The number of preemptible resource or maximum concurrent requests globally.
+  # QpsRateLimiterAdapter: qps is the average request count in one second supported by the server, it could be a Double or a Integer.
+  # IPQPSRateLimiterAdapter: similar to the QpsRateLimiterAdapter, qps could be a Double or a Integer.
+  # If not set, QpsRateLimiterAdapter with qps=1000 is the default strategy.
+  #
+  # Sample entries:
+  #
+  http = [
+    #  {
+    #    component = "GetNowBlockServlet",
+    #    strategy = "GlobalPreemptibleAdapter",
+    #    paramString = "permit=1"
+    #  },
+
+    #  {
+    #    component = "GetAccountServlet",
+    #    strategy = "IPQPSRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  },
+
+    #  {
+    #    component = "ListWitnessesServlet",
+    #    strategy = "QpsRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  }
+  ],
+
+  rpc = [
+    #  {
+    #    component = "protocol.Wallet/GetBlockByLatestNum2",
+    #    strategy = "GlobalPreemptibleAdapter",
+    #    paramString = "permit=1"
+    #  },
+
+    #  {
+    #    component = "protocol.Wallet/GetAccount",
+    #    strategy = "IPQPSRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  },
+
+    #  {
+    #    component = "protocol.Wallet/ListWitnesses",
+    #    strategy = "QpsRateLimiterAdapter",
+    #    paramString = "qps=1"
+    #  },
+  ]
+
+  p2p = {
+    # syncBlockChain = 3.0
+    # fetchInvData = 3.0
+    # disconnect = 1.0
+  }
+
+  # global qps, default 50000
+  global.qps = 50000
+  # IP-based global qps, default 10000
+  global.ip.qps = 10000
+}
+
 
 
 seed.node = {
   # List of the seed nodes. This is used to enable the node can connect when join one net at first.
   # If you deploy one private net, you must add some "ip:port" here for other node connecting.
-  # Seed nodes are stable full nodes, and the first SuperNode must be inclued in.
+  # Seed nodes are stable full nodes, and the first SuperNode must be included in.
   # example:
   # ip.list = [
   #   "ip:port",
-  #   "ip:port"
   # ]
   ip.list = [
    "tron-witness1:18888",
   ]
 }
 
-# if you use the fork database from mainnet keep this genesis.block the same as mainnet
 genesis.block = {
   # Reserve balance
   assets = [
@@ -268,38 +528,188 @@ genesis.block = {
     }
   ]
 
-  timestamp = "0" #2017-8-26 12:00:00
+  timestamp = "0" # Genesis block timestamp, milli seconds
 
   parentHash = "957dc2d350daecc7bb6a38f3938ebde0a0c1cedafe15f0edae4256a2907449f6"
 }
 
+# Optional. The default is empty. It is used when the witness account has set the witnessPermission.
+# When it is not empty, the localWitnessAccountAddress represents the address of the witness account,
+# and the localwitness is configured with the private key of the witnessPermissionAddress in the witness account.
+# When it is empty,the localwitness is configured with the private key of the witness account.
+# localWitnessAccountAddress =
+
 localwitness = [
   # address TCjptjyjenNKB2Y6EwyVT43DQyUUorxKWi
-  0ab0b4893c83102ed7be35eee6d50f081625ac75a07da6cb58b1ad2e9c18ce43  # you must enable this value and the witness address are match.
+  0ab0b4893c83102ed7be35eee6d50f081625ac75a07da6cb58b1ad2e9c18ce43
 ]
 
-#localwitnesskeystore = [
-#  "src/main/resources/localwitnesskeystore.json"  # if you do not set the localwitness above, you must set this value.Otherwise,your SuperNode can not produce the block.
-#]
+# localwitnesskeystore = [
+#  "localwitnesskeystore.json"
+# ]
 
 block = {
-  needSyncCheck = true # only one SR witness set false, the rest all false
+  needSyncCheck = true # only one SR witness set false, the rest all true
+  maintenanceTimeInterval = 21600000 // 6 hours: 21600000(ms)
+  proposalExpireTime = 259200000 // default value: 3 days: 259200000(ms), Note: this value is controlled by committee proposal
+  # checkFrozenTime = 1 // for test only
 }
+
+# Transaction reference block, default is "solid", configure to "head" may cause TaPos error
+trx.reference.block = "solid" // "head" or "solid"
+
+# This property sets the number of milliseconds after the creation of the transaction that is expired, default value is  60000.
+# trx.expiration.timeInMilliseconds = 60000
+
+# energy limit configuration - set to 0 to enable energy model from genesis block
+enery.limit.block.num = 0
 
 vm = {
-# tron smart contract virtual machine config, refer https://developers.tron.network/docs/tvm#differences-from-evm
   supportConstant = true
+  maxEnergyLimitForConstant = 100000000
   minTimeRatio = 0.0
   maxTimeRatio = 5.0
+  saveInternalTx = false
+  # lruCacheSize = 500
+  # vmTrace = false
+
+  # Indicates whether the node stores featured internal transactions, such as freeze, vote and so on. Default: false.
+  # saveFeaturedInternalTx = false
+
+  # Indicates whether the node stores the details of the internal transactions generated by the CANCELALLUNFREEZEV2 opcode,
+  # such as bandwidth/energy/tronpower cancel amount. Default: false.
+  # saveCancelAllUnfreezeV2Details = false
+
+  # In rare cases, transactions that will be within the specified maximum execution time (default 10(ms)) are re-executed and packaged
+  # longRunningTime = 10
+
+  # Indicates whether the node support estimate energy API. Default: false.
+  # estimateEnergy = false
+
+  # Indicates the max retry time for executing transaction in estimating energy. Default 3.
+  # estimateEnergyMaxRetry = 3
 }
 
+# These parameters are designed for private chain testing only and cannot be freely switched on or off in production systems.
 committee = {
   allowCreationOfContracts = 1
+  allowAdaptiveEnergy = 0
   changedDelegation = 1
   allowTvmTransferTrc10 = 1
+  # allowMultiSign = 0
+  # allowDelegateResource = 0
+  # allowSameTokenName = 0
+  # allowTvmConstantinople = 0
+  # allowTvmSolidity059 = 0
+  # forbidTransferToContract = 0
+  # allowShieldedTRC20Transaction = 0
+  # allowTvmIstanbul = 0
+  # allowMarketTransaction = 0
+  # allowProtoFilterNum = 0
+  # allowAccountStateRoot = 0
+  # allowPBFT = 0
+  # pBFTExpireNum = 0
+  # allowTransactionFeePool = 0
+  # allowBlackHoleOptimization = 0
+  # allowNewResourceModel = 0
+  # allowReceiptsMerkleRoot = 0
+  # allowTvmFreeze = 0
+  # allowTvmVote = 0
+  # unfreezeDelayDays = 0
+  # allowTvmLondon = 0
+  # allowTvmCompatibleEvm = 0
+  # allowNewRewardAlgorithm = 0
+  # allowAccountAssetOptimization = 0
+  # allowAssetOptimization = 0
+  # allowNewReward = 0
+  # memoFee = 0
+  # allowDelegateOptimization = 0
+  # allowDynamicEnergy = 0
+  # dynamicEnergyThreshold = 0
+  # dynamicEnergyMaxFactor = 0
+  # allowTvmShangHai = 0
+  # allowOldRewardOpt = 0
+  # allowEnergyAdjustment = 0
+  # allowStrictMath = 0
+  # allowTvmCancun = 0
+  # allowTvmBlob = 0
+  # consensusLogicOptimization = 0
+  # allowOptimizedReturnValueOfChainId = 0
+  # allowTvmOsaka = 0
 }
 
 event.subscribe = {
- # customized config for capture block or transaction info
- # refer https://tronprotocol.github.io/documentation-en/architecture/event/#configure-node for usage
+  enable = false // enable event subscribe, replaces deprecated CLI flag --es
+  native = {
+    useNativeQueue = true // if true, use native message queue, else use event plugin.
+    bindport = 5555 // bind port
+    sendqueuelength = 1000 //max length of send queue
+  }
+  version = 0
+  # Specify the starting block number to sync historical events. This is only applicable when version = 1.
+  # After performing a full event sync, set this value to 0 or a negative number.
+  # startSyncBlockNum = 1
+
+  path = "" // absolute path of plugin
+  server = "" // target server address to receive event triggers
+  # dbname|username|password, if you want to create indexes for collections when the collections
+  # are not exist, you can add version and set it to 2, as dbname|username|password|version
+  # if you use version 2 and one collection not exists, it will create index automaticaly;
+  # if you use version 2 and one collection exists, it will not create index, you must create index manually;
+  dbconfig = ""
+  contractParse = true
+  topics = [
+    {
+      triggerName = "block" // block trigger, the value can't be modified
+      enable = false
+      topic = "block" // plugin topic, the value could be modified
+      solidified = false // if set true, just need solidified block. Default: false
+    },
+    {
+      triggerName = "transaction"
+      enable = false
+      topic = "transaction"
+      solidified = false
+      ethCompatible = false // if set true, add transactionIndex, cumulativeEnergyUsed, preCumulativeLogCount, logList, energyUnitPrice. Default: false
+    },
+    {
+      triggerName = "contractevent" // contractevent represents contractlog data decoded by the ABI.
+      enable = false
+      topic = "contractevent"
+    },
+    {
+      triggerName = "contractlog"
+      enable = false
+      topic = "contractlog"
+      redundancy = false // if set true, contractevent will also be regarded as contractlog
+    },
+    {
+      triggerName = "solidity" // solidity block trigger(just include solidity block number and timestamp), the value can't be modified
+      enable = true            // Default: true
+      topic = "solidity"
+    },
+    {
+      triggerName = "solidityevent"
+      enable = false
+      topic = "solidityevent"
+    },
+    {
+      triggerName = "soliditylog"
+      enable = false
+      topic = "soliditylog"
+      redundancy = false // if set true, solidityevent will also be regarded as soliditylog
+    }
+  ]
+
+  filter = {
+    fromblock = "" // the value could be "", "earliest" or a specified block number as the beginning of the queried range
+    toblock = "" // the value could be "", "latest" or a specified block number as end of the queried range
+    contractAddress = [
+      "" // contract address you want to subscribe, if it's set to "", you will receive contract logs/events with any contract address.
+    ]
+
+    contractTopic = [
+      "" // contract topic you want to subscribe, if it's set to "", you will receive contract logs/events with any contract topic.
+    ]
+  }
 }

--- a/private_net/docker-compose.yml
+++ b/private_net/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - ./datadir:/java-tron/data # mount a local directory to make the blocks data persistent.
       - ./logs/tron-witness1:/java-tron/logs # map to host logs
     command: >
-      -jvm "{-Xmx12g -Xmn2g -XX:+UseConcMarkSweepGC -Xloggc:./logs/gc.log}" -c /java-tron/conf/private_net_config_witness1.conf -d /java-tron/data -w
+      -jvm "{-Xmx12g -Xmn2g -Xlog:gc:./logs/gc.log}" -c /java-tron/conf/private_net_config_witness1.conf -d /java-tron/data -w
 
     #  tron-witness2:
     #    image: tronprotocol/java-tron:latest
@@ -32,7 +32,7 @@ services:
     #      - ../conf:/java-tron/conf
     #      - ./logs/tron-witness2:/java-tron/logs
     #    command: >
-    #      -jvm "{-Xmx12g -Xmn2g -XX:+UseConcMarkSweepGC -Xloggc:./logs/gc.log}"
+    #      -jvm "{-Xmx12g -Xmn2g -Xlog:gc:./logs/gc.log}"
     #      -c /java-tron/conf/private_net_config_witness2.conf
     #      -w
   tron-node1:
@@ -48,7 +48,7 @@ services:
       - ../conf:/java-tron/conf
       - ./logs/tron-node1:/java-tron/logs
     command: >
-      -jvm "{-Xmx12g -Xmn2g -XX:+UseConcMarkSweepGC -Xloggc:./logs/gc.log}" -c /java-tron/conf/private_net_config_others.conf
+      -jvm "{-Xmx12g -Xmn2g -Xlog:gc:./logs/gc.log}" -c /java-tron/conf/private_net_config_others.conf
 
 #  tron-node2:
 #    image: tronprotocol/java-tron:latest
@@ -63,7 +63,7 @@ services:
 #      - ../conf:/java-tron/conf
 #      - ./logs/tron-node2:/java-tron/logs
 #    command: >
-#      -jvm "{-Xmx12g -Xmn2g -XX:+UseConcMarkSweepGC -Xloggc:./logs/gc.log}"
+#      -jvm "{-Xmx12g -Xmn2g -Xlog:gc:./logs/gc.log}"
 #      -c /java-tron/conf/private_net_config_others.conf
 networks:
   tron_private_network:


### PR DESCRIPTION
**What does this PR do?**

Synchronizes all 5 tron-docker config files with the latest java-tron upstream config structure (`framework/src/main/resources/config.conf`), and fixes JDK 17 incompatible JVM arguments in `private_net/docker-compose.yml`.

**Why are these changes required?**

The tron-docker config files had drifted significantly from java-tron's upstream config. New fields and sections introduced in recent releases (including v4.8.1) were missing, while deprecated fields were still present. This causes confusion for node operators and may lead to unexpected behavior.

This PR also lays the groundwork for a follow-up automated config drift detection — by first bringing all config files to a known-good baseline aligned with upstream, a future GitHub Action can periodically diff against java-tron's config and open an issue when structural drift is detected.

Key structural changes (all 5 config files):
- Add missing sections: `net {}`, `node.metrics.influxdb {}`, `rate.limiter.p2p {}`
- Add new fields: `storage.dbSettings.maxOpenFiles`, `node.jsonrpc.maxBlockFilterNum`, `event.subscribe.enable`, `trx.reference.block`, `txCache.initOptimization`, `rate.limiter.global.qps`
- Remove deprecated fields: `storage.index.directory`, `storage.backup {}`, `node.tcpNettyWorkThreadNum`, `node.udpNettyWorkThreadNum`
- Add ~30 committee proposal switches as inline comments for operator reference
- Update mainnet seed nodes to match v4.8.1 (last upstream update: 2026-02-04)

JVM fix (`docker-compose.yml`):
- Replace `-XX:+UseConcMarkSweepGC` (removed in JDK 14) — JDK 17 defaults to G1GC
- Replace deprecated `-Xloggc` with `-Xlog:gc` (unified logging framework, JDK 9+)

**This PR has been tested by:**
- Manual Testing: private net launched via `docker-compose up`, witness node produced blocks and full node synced successfully
- All config files parsed without HOCON syntax errors

**Follow up**

In future, can add a GitHub Action for automatic config structure drift detection between `tronprotocol/java-tron` upstream and tron-docker, triggering an issue when structural changes are detected.

**Extra details**

Network-specific values are preserved per config file:
- mainnet: `p2p.version = 11111`, mainnet genesis block and seed nodes
- Nile testnet: `p2p.version = 201910292`, Nile genesis block and seed nodes
- Private net: `p2p.version = 1`, test accounts (TestA–E), witness private keys
