### PR TITLE
feat(dashboard): add block transaction count and SR set change panels

### DIFF
--- a/metric_monitor/README.md
+++ b/metric_monitor/README.md
@@ -147,7 +147,7 @@ Verify the latency of all transactions' signatures when processing a block:
 - `tron:verify_sign_latency_seconds_count`: Count of events
 - `tron:verify_sign_latency_seconds_sum`: Total sum of all observed values
 
-Histogram of transaction count per block, with buckets `[0, 10, 50, 100, 200, 500, 1000, 2000, 5000, 10000]`. Empty blocks can be queried via the `le="0.0"` bucket; the distribution buckets enable transaction volume analysis (P50/P99, large-block ratio, etc.):
+Histogram of transaction count per block, with buckets `[0, 20, 50, 80, 100, 120, 140, 160, 180, 200, 230, 260, 300, 500, 2000]` (densified around 0–300 for percentile interpolation in the typical per-SR TPS range). Empty blocks can be queried via the `le="0.0"` bucket; the distribution buckets enable transaction volume analysis (P50/P99, large-block ratio, etc.):
 - `tron:block_transaction_count_bucket`: Cumulative counters per bucket. Label: `miner` (SR address).
 - `tron:block_transaction_count_count`: Count of observed blocks
 - `tron:block_transaction_count_sum`: Total sum of all observed transaction counts

--- a/metric_monitor/README.md
+++ b/metric_monitor/README.md
@@ -90,6 +90,7 @@ The TRON node metrics can be viewed through the Grafana dashboard or directly at
 - `tron:header_time`: The latest block time of java-tron on this node
 - `tron:header_height`: The latest block height of java-tron on this node
 - `tron:miner_total`: Used to display the blocks produced by a certain SR
+- `tron:sr_set_change_total`: Counter of SR set membership changes detected at each maintenance time interval. Labels: `action` (`add`/`remove`), `witness` (SR address). Useful for tracking governance and consensus participant rotation.
 
 ### Node system status
 Metric of specific container:
@@ -145,6 +146,11 @@ Verify the latency of all transactions' signatures when processing a block:
 - `tron:verify_sign_latency_seconds_bucket`: Cumulative counters for
 - `tron:verify_sign_latency_seconds_count`: Count of events
 - `tron:verify_sign_latency_seconds_sum`: Total sum of all observed values
+
+Histogram of transaction count per block, with buckets `[0, 10, 50, 100, 200, 500, 1000, 2000, 5000, 10000]`. Empty blocks can be queried via the `le="0.0"` bucket; the distribution buckets enable transaction volume analysis (P50/P99, large-block ratio, etc.):
+- `tron:block_transaction_count_bucket`: Cumulative counters per bucket. Label: `miner` (SR address).
+- `tron:block_transaction_count_count`: Count of observed blocks
+- `tron:block_transaction_count_sum`: Total sum of all observed transaction counts
 
 Check the usage from dashboard panel (enter edit mode), or by searching in [grafana_dashboard_tron_server.json](grafana_dashboard/grafana_dashboard_tron_server.json).
 ![image](../images/metric_block_latency.png)

--- a/metric_monitor/README.md
+++ b/metric_monitor/README.md
@@ -147,7 +147,7 @@ Verify the latency of all transactions' signatures when processing a block:
 - `tron:verify_sign_latency_seconds_count`: Count of events
 - `tron:verify_sign_latency_seconds_sum`: Total sum of all observed values
 
-Histogram of transaction count per block, with buckets `[0, 20, 50, 80, 100, 120, 140, 160, 180, 200, 230, 260, 300, 500, 2000]` (densified around 0–300 for percentile interpolation in the typical per-SR TPS range). Empty blocks can be queried via the `le="0.0"` bucket; the distribution buckets enable transaction volume analysis (P50/P99, large-block ratio, etc.):
+Histogram of transaction count per block, with buckets `[0, 20, 50, 80, 100, 120, 140, 160, 180, 200, 230, 260, 300, 500, 2000]` (densified around 0–300 for percentile interpolation in the typical per-SR TPS range). Empty blocks can be queried via the `le="0.0"` bucket; the distribution buckets enable transaction volume analysis (P95/P99, large-block ratio, etc.):
 - `tron:block_transaction_count_bucket`: Cumulative counters per bucket. Label: `miner` (SR address).
 - `tron:block_transaction_count_count`: Count of observed blocks
 - `tron:block_transaction_count_sum`: Total sum of all observed transaction counts

--- a/metric_monitor/grafana_dashboard/java-tron-server.json
+++ b/metric_monitor/grafana_dashboard/java-tron-server.json
@@ -2508,12 +2508,672 @@
       "type": "row"
     },
     {
-      "collapsed": false,
+      "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 19
+      },
+      "id": 110,
+      "panels": [
+        {
+          "datasource": "${datasource}",
+          "description": "Ratio of blocks with zero transactions over total blocks.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percentunit",
+              "max": 1,
+              "min": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 20
+          },
+          "id": 111,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "rate(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"0.0\"}[$__interval]) / ignoring(le) rate(tron:block_transaction_count_count{group=`$group`,instance=`$instance`}[$__interval])",
+              "legendFormat": "{{miner}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Empty Block Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${datasource}",
+          "description": "Number of empty blocks per SR in the last 1 hour.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Empty Blocks",
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineWidth": 1,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 20
+          },
+          "id": 112,
+          "options": {
+            "legend": {
+              "calcs": [
+                "sum"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"0.0\"}[1h]))",
+              "instant": true,
+              "legendFormat": "{{miner}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Per-SR Empty Block Count (1h)",
+          "type": "barchart"
+        },
+        {
+          "datasource": "${datasource}",
+          "description": "Average number of transactions per block.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Avg TXs / Block",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short",
+              "min": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 28
+          },
+          "id": 113,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "rate(tron:block_transaction_count_sum{group=`$group`,instance=`$instance`}[$__interval]) / rate(tron:block_transaction_count_count{group=`$group`,instance=`$instance`}[$__interval])",
+              "legendFormat": "{{miner}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Avg Transactions per Block",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "${datasource}",
+          "description": "Distribution of transaction counts per block across histogram buckets.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Blocks",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "bars",
+                "fillOpacity": 80,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 28
+          },
+          "id": 114,
+          "options": {
+            "legend": {
+              "calcs": [
+                "sum"
+              ],
+              "displayMode": "table",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"0.0\"}[$__interval]))",
+              "legendFormat": "0 (empty)",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"10.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"0.0\"}[$__interval]))",
+              "legendFormat": "1-10",
+              "refId": "B"
+            },
+            {
+              "exemplar": true,
+              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"50.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"10.0\"}[$__interval]))",
+              "legendFormat": "11-50",
+              "refId": "C"
+            },
+            {
+              "exemplar": true,
+              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"100.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"50.0\"}[$__interval]))",
+              "legendFormat": "51-100",
+              "refId": "D"
+            },
+            {
+              "exemplar": true,
+              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"200.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"100.0\"}[$__interval]))",
+              "legendFormat": "101-200",
+              "refId": "E"
+            },
+            {
+              "exemplar": true,
+              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"500.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"200.0\"}[$__interval]))",
+              "legendFormat": "201-500",
+              "refId": "F"
+            },
+            {
+              "exemplar": true,
+              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"1000.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"500.0\"}[$__interval]))",
+              "legendFormat": "501-1000",
+              "refId": "G"
+            },
+            {
+              "exemplar": true,
+              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"+Inf\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"1000.0\"}[$__interval]))",
+              "legendFormat": "1000+",
+              "refId": "H"
+            }
+          ],
+          "title": "Block Transaction Count Distribution",
+          "type": "timeseries"
+        }
+      ],
+      "title": "Block Metrics",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 20
+      },
+      "id": 115,
+      "panels": [
+        {
+          "datasource": "${datasource}",
+          "description": "Table of SR set change events showing additions and removals.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "action"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 80
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "add": {
+                            "text": "ADD",
+                            "color": "green"
+                          },
+                          "remove": {
+                            "text": "REMOVE",
+                            "color": "red"
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "witness"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 360
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 80
+                  },
+                  {
+                    "id": "displayName",
+                    "value": "Count"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Time"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 200
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 21
+          },
+          "id": 116,
+          "options": {
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Time",
+                "desc": true
+              }
+            ],
+            "cellHeight": "sm",
+            "footer": {
+              "show": false
+            }
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "tron:sr_set_change_total{group=`$group`,instance=`$instance`}",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "__name__": true,
+                  "group": true,
+                  "instance": true,
+                  "job": true
+                },
+                "indexByName": {
+                  "Time": 0,
+                  "action": 1,
+                  "witness": 2,
+                  "Value": 3
+                }
+              }
+            }
+          ],
+          "title": "SR Set Change Events",
+          "type": "table"
+        },
+        {
+          "datasource": "${datasource}",
+          "description": "Cumulative count of SR additions and removals.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 5
+                  },
+                  {
+                    "color": "red",
+                    "value": 10
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "SR Removed"
+                },
+                "properties": [
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": null
+                        },
+                        {
+                          "color": "orange",
+                          "value": 5
+                        },
+                        {
+                          "color": "red",
+                          "value": 10
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 21
+          },
+          "id": 117,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "targets": [
+            {
+              "exemplar": true,
+              "expr": "sum(tron:sr_set_change_total{group=`$group`,instance=`$instance`,action=\"add\"}) or vector(0)",
+              "legendFormat": "SR Added",
+              "refId": "A"
+            },
+            {
+              "exemplar": true,
+              "expr": "sum(tron:sr_set_change_total{group=`$group`,instance=`$instance`,action=\"remove\"}) or vector(0)",
+              "legendFormat": "SR Removed",
+              "refId": "B"
+            }
+          ],
+          "title": "SR Set Change Total",
+          "type": "stat"
+        }
+      ],
+      "title": "SR Set Change",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
       },
       "id": 46,
       "panels": [],

--- a/metric_monitor/grafana_dashboard/java-tron-server.json
+++ b/metric_monitor/grafana_dashboard/java-tron-server.json
@@ -2854,14 +2854,14 @@
             },
             {
               "exemplar": true,
-              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"10.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"0.0\"}[$__interval]))",
-              "legendFormat": "1-10",
+              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"20.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"0.0\"}[$__interval]))",
+              "legendFormat": "1-20",
               "refId": "B"
             },
             {
               "exemplar": true,
-              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"50.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"10.0\"}[$__interval]))",
-              "legendFormat": "11-50",
+              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"50.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"20.0\"}[$__interval]))",
+              "legendFormat": "21-50",
               "refId": "C"
             },
             {
@@ -2878,21 +2878,27 @@
             },
             {
               "exemplar": true,
-              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"500.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"200.0\"}[$__interval]))",
-              "legendFormat": "201-500",
+              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"300.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"200.0\"}[$__interval]))",
+              "legendFormat": "201-300",
               "refId": "F"
             },
             {
               "exemplar": true,
-              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"1000.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"500.0\"}[$__interval]))",
-              "legendFormat": "501-1000",
+              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"500.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"300.0\"}[$__interval]))",
+              "legendFormat": "301-500",
               "refId": "G"
             },
             {
               "exemplar": true,
-              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"+Inf\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"1000.0\"}[$__interval]))",
-              "legendFormat": "1000+",
+              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"2000.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"500.0\"}[$__interval]))",
+              "legendFormat": "501-2000",
               "refId": "H"
+            },
+            {
+              "exemplar": true,
+              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"+Inf\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"2000.0\"}[$__interval]))",
+              "legendFormat": "2000+",
+              "refId": "I"
             }
           ],
           "title": "Block Transaction Count Distribution",

--- a/metric_monitor/grafana_dashboard/java-tron-server.json
+++ b/metric_monitor/grafana_dashboard/java-tron-server.json
@@ -25,7 +25,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 4,
+  "id": null,
   "links": [],
   "panels": [
     {
@@ -2502,24 +2502,10 @@
           ],
           "title": "Block Push Lock Acquire Latency",
           "type": "timeseries"
-        }
-      ],
-      "title": "Block",
-      "type": "row"
-    },
-    {
-      "collapsed": true,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 19
-      },
-      "id": 110,
-      "panels": [
+        },
         {
           "datasource": "${datasource}",
-          "description": "Ratio of blocks with zero transactions over total blocks.",
+          "description": "95th percentile of transaction count per block.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2529,11 +2515,11 @@
                 "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
-                "axisLabel": "",
+                "axisLabel": "TX Count",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "drawStyle": "line",
-                "fillOpacity": 20,
+                "fillOpacity": 10,
                 "gradientMode": "none",
                 "hideFrom": {
                   "legend": false,
@@ -2563,15 +2549,10 @@
                   {
                     "color": "green",
                     "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
                   }
                 ]
               },
-              "unit": "percentunit",
-              "max": 1,
+              "unit": "short",
               "min": 0
             },
             "overrides": []
@@ -2580,7 +2561,7 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 20
+            "y": 126
           },
           "id": 111,
           "options": {
@@ -2600,92 +2581,19 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "rate(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"0.0\"}[$__interval]) / ignoring(le) rate(tron:block_transaction_count_count{group=`$group`,instance=`$instance`}[$__interval])",
-              "legendFormat": "{{miner}}",
+              "expr": "histogram_quantile(0.95, rate(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`}[$__interval]))",
+              "legendFormat": "P95 {{miner}}",
               "refId": "A"
-            }
-          ],
-          "title": "Empty Block Rate",
-          "type": "timeseries"
-        },
-        {
-          "datasource": "${datasource}",
-          "description": "Number of empty blocks per SR in the last 1 hour.",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "Empty Blocks",
-                "axisPlacement": "auto",
-                "fillOpacity": 80,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineWidth": 1,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
-                  }
-                ]
-              },
-              "unit": "short"
             },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 20
-          },
-          "id": 112,
-          "options": {
-            "legend": {
-              "calcs": [
-                "sum"
-              ],
-              "displayMode": "table",
-              "placement": "bottom"
-            },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
-          },
-          "targets": [
             {
               "exemplar": true,
-              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"0.0\"}[1h]))",
-              "instant": true,
-              "legendFormat": "{{miner}}",
-              "refId": "A"
+              "expr": "histogram_quantile(0.99, rate(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`}[$__interval]))",
+              "legendFormat": "P99 {{miner}}",
+              "refId": "B"
             }
           ],
-          "title": "Per-SR Empty Block Count (1h)",
-          "type": "barchart"
+          "title": "P95 / P99 Block Transaction Count",
+          "type": "timeseries"
         },
         {
           "datasource": "${datasource}",
@@ -2744,8 +2652,8 @@
           "gridPos": {
             "h": 8,
             "w": 12,
-            "x": 0,
-            "y": 28
+            "x": 12,
+            "y": 126
           },
           "id": 113,
           "options": {
@@ -2775,41 +2683,11 @@
         },
         {
           "datasource": "${datasource}",
-          "description": "Distribution of transaction counts per block across histogram buckets.",
+          "description": "Timestamp of the most recent empty block produced by each witness.",
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "palette-classic"
-              },
-              "custom": {
-                "axisBorderShow": false,
-                "axisCenteredZero": false,
-                "axisColorMode": "text",
-                "axisLabel": "Blocks",
-                "axisPlacement": "auto",
-                "barAlignment": 0,
-                "drawStyle": "bars",
-                "fillOpacity": 80,
-                "gradientMode": "none",
-                "hideFrom": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                },
-                "lineWidth": 1,
-                "pointSize": 5,
-                "scaleDistribution": {
-                  "type": "linear"
-                },
-                "showPoints": "never",
-                "spanNulls": false,
-                "stacking": {
-                  "group": "A",
-                  "mode": "normal"
-                },
-                "thresholdsStyle": {
-                  "mode": "off"
-                }
+                "mode": "thresholds"
               },
               "mappings": [],
               "thresholds": {
@@ -2821,91 +2699,48 @@
                   }
                 ]
               },
-              "unit": "short"
+              "unit": "dateTimeAsIso"
             },
             "overrides": []
           },
           "gridPos": {
             "h": 8,
-            "w": 12,
-            "x": 12,
-            "y": 28
+            "w": 24,
+            "x": 0,
+            "y": 134
           },
-          "id": 114,
+          "id": 118,
           "options": {
-            "legend": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
               "calcs": [
-                "sum"
+                "lastNotNull"
               ],
-              "displayMode": "table",
-              "placement": "bottom"
+              "fields": "",
+              "values": false
             },
-            "tooltip": {
-              "mode": "multi",
-              "sort": "desc"
-            }
+            "showPercentChange": false,
+            "textMode": "value_and_name",
+            "wideLayout": true
           },
+          "pluginVersion": "11.6.0",
           "targets": [
             {
               "exemplar": true,
-              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"0.0\"}[$__interval]))",
-              "legendFormat": "0 (empty)",
+              "expr": "max_over_time((timestamp(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"0.0\"}) and (tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"0.0\"} != tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"0.0\"} offset 1m))[1h:1m]) * 1000",
+              "legendFormat": "{{miner}}",
               "refId": "A"
-            },
-            {
-              "exemplar": true,
-              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"20.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"0.0\"}[$__interval]))",
-              "legendFormat": "1-20",
-              "refId": "B"
-            },
-            {
-              "exemplar": true,
-              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"50.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"20.0\"}[$__interval]))",
-              "legendFormat": "21-50",
-              "refId": "C"
-            },
-            {
-              "exemplar": true,
-              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"100.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"50.0\"}[$__interval]))",
-              "legendFormat": "51-100",
-              "refId": "D"
-            },
-            {
-              "exemplar": true,
-              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"200.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"100.0\"}[$__interval]))",
-              "legendFormat": "101-200",
-              "refId": "E"
-            },
-            {
-              "exemplar": true,
-              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"300.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"200.0\"}[$__interval]))",
-              "legendFormat": "201-300",
-              "refId": "F"
-            },
-            {
-              "exemplar": true,
-              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"500.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"300.0\"}[$__interval]))",
-              "legendFormat": "301-500",
-              "refId": "G"
-            },
-            {
-              "exemplar": true,
-              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"2000.0\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"500.0\"}[$__interval]))",
-              "legendFormat": "501-2000",
-              "refId": "H"
-            },
-            {
-              "exemplar": true,
-              "expr": "round(increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"+Inf\"}[$__interval]) - increase(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"2000.0\"}[$__interval]))",
-              "legendFormat": "2000+",
-              "refId": "I"
             }
           ],
-          "title": "Block Transaction Count Distribution",
-          "type": "timeseries"
+          "title": "Last Empty Block",
+          "type": "stat"
         }
       ],
-      "title": "Block Metrics",
+      "title": "Block",
       "type": "row"
     },
     {
@@ -3170,7 +3005,7 @@
           "type": "stat"
         }
       ],
-      "title": "SR Set Change",
+      "title": "SR Set",
       "type": "row"
     },
     {
@@ -3211,7 +3046,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 20
+        "y": 22
       },
       "id": 20,
       "interval": "3s",
@@ -3327,7 +3162,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 20
+        "y": 22
       },
       "id": 17,
       "interval": "10m",
@@ -3395,7 +3230,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 28
+        "y": 30
       },
       "id": 108,
       "interval": "3s",
@@ -3529,7 +3364,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 28
+        "y": 30
       },
       "id": 107,
       "interval": "10m",
@@ -3654,7 +3489,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 36
+        "y": 38
       },
       "id": 16,
       "interval": "10m",
@@ -3758,7 +3593,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 36
+        "y": 38
       },
       "id": 106,
       "options": {
@@ -5541,6 +5376,6 @@
   },
   "timezone": "",
   "title": "java-tron-server",
-  "uid": "WAY66gQ07X",
+  "uid": "java-tron-server",
   "version": 8
 }

--- a/metric_monitor/grafana_dashboard/java-tron-server.json
+++ b/metric_monitor/grafana_dashboard/java-tron-server.json
@@ -2680,64 +2680,6 @@
           ],
           "title": "Avg Transactions per Block",
           "type": "timeseries"
-        },
-        {
-          "datasource": "${datasource}",
-          "description": "Timestamp of the most recent empty block produced by each witness.",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "mode": "thresholds"
-              },
-              "mappings": [],
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "green",
-                    "value": null
-                  }
-                ]
-              },
-              "unit": "dateTimeAsIso"
-            },
-            "overrides": []
-          },
-          "gridPos": {
-            "h": 8,
-            "w": 24,
-            "x": 0,
-            "y": 134
-          },
-          "id": 118,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "center",
-            "orientation": "auto",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "value_and_name",
-            "wideLayout": true
-          },
-          "pluginVersion": "11.6.0",
-          "targets": [
-            {
-              "exemplar": true,
-              "expr": "max_over_time((timestamp(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"0.0\"}) and (tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"0.0\"} != tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`,le=\"0.0\"} offset 1m))[1h:1m]) * 1000",
-              "legendFormat": "{{miner}}",
-              "refId": "A"
-            }
-          ],
-          "title": "Last Empty Block",
-          "type": "stat"
         }
       ],
       "title": "Block",

--- a/metric_monitor/grafana_dashboard/java-tron-server.json
+++ b/metric_monitor/grafana_dashboard/java-tron-server.json
@@ -2581,13 +2581,13 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "histogram_quantile(0.95, rate(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`}[$__interval]))",
+              "expr": "histogram_quantile(0.95, sum by (le, miner) (rate(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`}[$__rate_interval])))",
               "legendFormat": "P95 {{miner}}",
               "refId": "A"
             },
             {
               "exemplar": true,
-              "expr": "histogram_quantile(0.99, rate(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`}[$__interval]))",
+              "expr": "histogram_quantile(0.99, sum by (le, miner) (rate(tron:block_transaction_count_bucket{group=`$group`,instance=`$instance`}[$__rate_interval])))",
               "legendFormat": "P99 {{miner}}",
               "refId": "B"
             }
@@ -2673,7 +2673,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "rate(tron:block_transaction_count_sum{group=`$group`,instance=`$instance`}[$__interval]) / rate(tron:block_transaction_count_count{group=`$group`,instance=`$instance`}[$__interval])",
+              "expr": "rate(tron:block_transaction_count_sum{group=`$group`,instance=`$instance`}[$__rate_interval]) / rate(tron:block_transaction_count_count{group=`$group`,instance=`$instance`}[$__rate_interval])",
               "legendFormat": "{{miner}}",
               "refId": "A"
             }
@@ -2845,7 +2845,7 @@
               }
             }
           ],
-          "title": "SR Set Change Events",
+          "title": "SR Set Change Counts",
           "type": "table"
         },
         {


### PR DESCRIPTION
**What does this PR do?**

Add new panels to the `java-tron-server` Grafana dashboard template to visualize the metrics introduced in tronprotocol/java-tron#6624:

1. **Block** row (2 new panels added to the existing row):
   - **P95 / P99 Block Transaction Count** — 95th/99th percentile of transaction count per block (timeseries)
   - **Avg Transactions per Block** — average transaction count per block (timeseries)

2. **SR Set** row (2 panels):
   - **SR Set Change Counts** — table of cumulative add/remove counts per witness with color-coded action labels
   - **SR Set Change Total** — cumulative stat for SR additions and removals with threshold coloring

**Why are these changes required?**

tronprotocol/java-tron#6624 introduces `tron:block_transaction_count` (histogram) and `tron:sr_set_change` (counter) metrics. This PR updates the official Grafana dashboard template so node operators can import and use the new panels directly, reducing onboarding effort as suggested in [this comment](https://github.com/tronprotocol/java-tron/pull/6624#issuecomment-4211335343).

**This PR has been tested by:**
- Manual Testing (private net with Prometheus + Grafana, java-tron v4.8.2 built from source)

**Follow up**

- Depends on tronprotocol/java-tron#6624 being merged (new metrics must exist for panels to populate data)

**Extra details**

- New block panels are integrated into the existing "Block" row; the "SR Set" row is inserted between "Block" and "Net".
- All PromQL queries follow the existing dashboard conventions (`$group`, `$instance`, backtick syntax).
- No changes to existing panels; safe to merge independently (panels show "No data" until java-tron metrics are available).