### PR TITLE
build(docker): use PGP-verified OpenJDK 8 for amd64 images

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -3,19 +3,27 @@ ARG VERSION="dev"
 ENV NO_PROXY_CACHE="-o Acquire::BrokenProxy=true -o Acquire::http::No-Cache=true -o Acquire::http::Pipeline-Depth=0"
 
 ENV TMP_DIR="/tron-build"
-ENV JDK_TAR="jdk-8u202-linux-x64.tar.gz"
-ENV JDK_DIR="jdk1.8.0_202"
-ENV JDK_SHA256="9a5c32411a6a06e22b69c495b7975034409fa1652d03aeb8eb5b6f59fd4594e0"
+ENV OPENJDK8_URL="https://api.adoptium.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/eclipse"
+ENV ADOPTIUM_SIGNING_FINGERPRINT="3B04D753C9050D9A5D343F39843C48A565F8F04B"
+ENV JDK_DIR="/usr/local/openjdk-8"
 ENV BASE_DIR="/java-tron"
 
 # Update and install dependencies without using any cache
 RUN apt-get update $NO_PROXY_CACHE  && \
-  apt-get --quiet --yes install git wget 7zip curl jq libtcmalloc-minimal4 && \
-  wget -P /usr/local https://github.com/frekele/oracle-java/releases/download/8u202-b08/$JDK_TAR \
-  && echo "$JDK_SHA256 /usr/local/$JDK_TAR" | sha256sum -c \
-  && tar -zxf /usr/local/$JDK_TAR -C /usr/local\
-  && rm /usr/local/$JDK_TAR \
-  && export JAVA_HOME=/usr/local/$JDK_DIR \
+  apt-get --quiet --yes install git wget 7zip curl jq libtcmalloc-minimal4 gnupg dirmngr ca-certificates && \
+  cd /usr/local \
+  && FETCH_URL="$(curl -fsS -w "%{redirect_url}" -o /dev/null "$OPENJDK8_URL")" \
+  && JDK_TAR="$(curl -fsSL -w "%{filename_effective}" -O "$FETCH_URL")" \
+  && curl -fsSLo "$JDK_TAR.sig" "$FETCH_URL.sig" \
+  && GNUPGHOME="$(mktemp -d)" \
+  && export GNUPGHOME \
+  && gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$ADOPTIUM_SIGNING_FINGERPRINT" \
+  && gpg --batch --verify "$JDK_TAR.sig" "$JDK_TAR" \
+  && rm -rf "$GNUPGHOME" "$JDK_TAR.sig" \
+  && mkdir -p "$JDK_DIR" \
+  && tar -zxf "$JDK_TAR" -C "$JDK_DIR" --strip-components=1 \
+  && rm "$JDK_TAR" \
+  && export JAVA_HOME=$JDK_DIR \
   && export CLASSPATH=$JAVA_HOME/lib/dt.jar:$JAVA_HOME/lib/tools.jar \
   && export PATH=$PATH:$JAVA_HOME/bin \
   && echo "git clone" \
@@ -30,8 +38,8 @@ RUN apt-get update $NO_PROXY_CACHE  && \
   && mv java-tron-1.0.0 $BASE_DIR \
   && rm -rf $TMP_DIR \
   && rm -rf ~/.gradle \
-  && mv /usr/local/$JDK_DIR/jre /usr/local \
-  && rm -rf /usr/local/$JDK_DIR \
+  && mv $JDK_DIR/jre /usr/local \
+  && rm -rf $JDK_DIR \
   && wget -O $BASE_DIR/config.conf https://raw.githubusercontent.com/tronprotocol/tron-deployment/master/main_net_config.conf \
   # Clean apt cache
   && apt-get clean \

--- a/tools/docker/Dockerfile.nile
+++ b/tools/docker/Dockerfile.nile
@@ -3,19 +3,27 @@ ARG VERSION="dev"
 ENV NO_PROXY_CACHE="-o Acquire::BrokenProxy=true -o Acquire::http::No-Cache=true -o Acquire::http::Pipeline-Depth=0"
 
 ENV TMP_DIR="/tron-build"
-ENV JDK_TAR="jdk-8u202-linux-x64.tar.gz"
-ENV JDK_DIR="jdk1.8.0_202"
-ENV JDK_SHA256="9a5c32411a6a06e22b69c495b7975034409fa1652d03aeb8eb5b6f59fd4594e0"
+ENV OPENJDK8_URL="https://api.adoptium.net/v3/binary/latest/8/ga/linux/x64/jdk/hotspot/normal/eclipse"
+ENV ADOPTIUM_SIGNING_FINGERPRINT="3B04D753C9050D9A5D343F39843C48A565F8F04B"
+ENV JDK_DIR="/usr/local/openjdk-8"
 ENV BASE_DIR="/java-tron"
 
 # Update and install dependencies without using any cache
 RUN apt-get update $NO_PROXY_CACHE  && \
-  apt-get --quiet --yes install git wget 7zip curl jq libtcmalloc-minimal4 && \
-  wget -P /usr/local https://github.com/frekele/oracle-java/releases/download/8u202-b08/$JDK_TAR \
-  && echo "$JDK_SHA256 /usr/local/$JDK_TAR" | sha256sum -c \
-  && tar -zxf /usr/local/$JDK_TAR -C /usr/local\
-  && rm /usr/local/$JDK_TAR \
-  && export JAVA_HOME=/usr/local/$JDK_DIR \
+  apt-get --quiet --yes install git wget 7zip curl jq libtcmalloc-minimal4 gnupg dirmngr ca-certificates && \
+  cd /usr/local \
+  && FETCH_URL="$(curl -fsS -w "%{redirect_url}" -o /dev/null "$OPENJDK8_URL")" \
+  && JDK_TAR="$(curl -fsSL -w "%{filename_effective}" -O "$FETCH_URL")" \
+  && curl -fsSLo "$JDK_TAR.sig" "$FETCH_URL.sig" \
+  && GNUPGHOME="$(mktemp -d)" \
+  && export GNUPGHOME \
+  && gpg --batch --keyserver hkps://keyserver.ubuntu.com --recv-keys "$ADOPTIUM_SIGNING_FINGERPRINT" \
+  && gpg --batch --verify "$JDK_TAR.sig" "$JDK_TAR" \
+  && rm -rf "$GNUPGHOME" "$JDK_TAR.sig" \
+  && mkdir -p "$JDK_DIR" \
+  && tar -zxf "$JDK_TAR" -C "$JDK_DIR" --strip-components=1 \
+  && rm "$JDK_TAR" \
+  && export JAVA_HOME=$JDK_DIR \
   && export CLASSPATH=$JAVA_HOME/lib/dt.jar:$JAVA_HOME/lib/tools.jar \
   && export PATH=$PATH:$JAVA_HOME/bin \
   && echo "git clone" \
@@ -30,8 +38,8 @@ RUN apt-get update $NO_PROXY_CACHE  && \
   && mv java-tron-1.0.0 $BASE_DIR \
   && rm -rf $TMP_DIR \
   && rm -rf ~/.gradle \
-  && mv /usr/local/$JDK_DIR/jre /usr/local \
-  && rm -rf /usr/local/$JDK_DIR \
+  && mv $JDK_DIR/jre /usr/local \
+  && rm -rf $JDK_DIR \
   && wget -O $BASE_DIR/config.conf https://raw.githubusercontent.com/tronprotocol/tron-deployment/master/test_net_config.conf \
   # Clean apt cache
   && apt-get clean \

--- a/tools/docker/tests/dgoss
+++ b/tools/docker/tests/dgoss
@@ -80,7 +80,7 @@ trap 'ret=$?;cleanup;exit $ret' EXIT
 GOSS_PATH="${GOSS_PATH:-$(which goss 2> /dev/null || true)}"
 [[ $GOSS_PATH ]] || { error "Couldn't find goss installation, please set GOSS_PATH to it"; }
 [[ ${GOSS_OPTS+x} ]] || GOSS_OPTS="--color --format documentation"
-[[ ${GOSS_WAIT_OPTS+x} ]] || GOSS_WAIT_OPTS="-r 30s -s 1s > /dev/null"
+[[ ${GOSS_WAIT_OPTS+x} ]] || GOSS_WAIT_OPTS="-r 60s -s 2s > /dev/null"
 GOSS_SLEEP=${GOSS_SLEEP:-1.0}
 
 case "$1" in


### PR DESCRIPTION
**What does this PR do?**
Replace the fixed Oracle JDK 8u202 download with the latest Adoptium OpenJDK 8 binary for mainnet and Nile Docker amd64 images.

Extend dgoss wait retry settings to reduce startup timing failures during Docker image tests.

**Why are these changes required?**
Improve security.

**This PR has been tested by:**
- Manual Testing

**Follow up**

**Extra details**
