### PR TITLE
fix(monitor): bump prometheus to v3.11.3 and thanos to v0.41.0

### DIFF
--- a/metric_monitor/docker-compose/docker-compose-quick-start.yml
+++ b/metric_monitor/docker-compose/docker-compose-quick-start.yml
@@ -6,7 +6,7 @@ services:
       service: tron-node
 
   prometheus:
-    image: prom/prometheus:v3.10.0
+    image: prom/prometheus:v3.11.3
     container_name: prometheus
     deploy:
       resources:

--- a/metric_monitor/docker-compose/prometheus.yml
+++ b/metric_monitor/docker-compose/prometheus.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   prometheus:
-    image: prom/prometheus:v3.10.0
+    image: prom/prometheus:v3.11.3
     container_name: prometheus
     security_opt:
       - no-new-privileges:true

--- a/metric_monitor/docker-compose/thanos-querier.yml
+++ b/metric_monitor/docker-compose/thanos-querier.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   thanos-querier:
-    image: quay.io/thanos/thanos:v0.33.0
+    image: quay.io/thanos/thanos:v0.41.0
     container_name: thanos-querier
     ports:
       - "9091:9091"

--- a/metric_monitor/docker-compose/thanos-receive.yml
+++ b/metric_monitor/docker-compose/thanos-receive.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   thanos-receive:
-    image: quay.io/thanos/thanos:v0.33.0
+    image: quay.io/thanos/thanos:v0.41.0
     container_name: thanos-receive
     volumes:
       - ../receive-data-0:/receive/data

--- a/metric_monitor/docker-compose/thanos-store.yml
+++ b/metric_monitor/docker-compose/thanos-store.yml
@@ -1,7 +1,7 @@
 version: '3.8'
 services:
   thanos-store:
-    image: quay.io/thanos/thanos:v0.33.0
+    image: quay.io/thanos/thanos:v0.41.0
     container_name: thanos-store
     ports:
       - "10911:10911"  # HTTP


### PR DESCRIPTION
Prometheus v3.10.0 falls in the vulnerable range of CVE-2026-42154 (GHSA-8rm2-7qqf-34qm), a remote_read DoS via crafted snappy payload. Bump to v3.11.3 which contains the fix. Thanos v0.33.0 is also upgraded to the latest stable v0.41.0.

**What does this PR do?**

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**
