### PR TITLE
fix(toolkit): set witness flag for fork accounts

### DIFF
--- a/tools/toolkit/src/main/java/org/tron/plugins/DbFork.java
+++ b/tools/toolkit/src/main/java/org/tron/plugins/DbFork.java
@@ -127,6 +127,22 @@ public class DbFork implements Callable<Integer> {
     storageRowStore = DbTool.getDB(srcDir, STORAGE_ROW_STORE);
   }
 
+  private AccountCapsule getOrCreateAccountCapsule(byte[] address) {
+    byte[] value = accountStore.get(address);
+    Account account = null;
+    try {
+      account = ArrayUtils.isEmpty(value) ? null : Account.parseFrom(value);
+    } catch (InvalidProtocolBufferException e) {
+      e.printStackTrace();
+      System.exit(-1);
+    }
+
+    if (Objects.isNull(account)) {
+      account = Account.newBuilder().setAddress(ByteString.copyFrom(address)).build();
+    }
+    return new AccountCapsule(account);
+  }
+
   @Override
   public Integer call() throws IOException, RocksDBException {
     if (help) {
@@ -189,7 +205,9 @@ public class DbFork implements Callable<Integer> {
             ByteString address = ByteString.copyFrom(
                 Commons.decodeFromBase58Check(w.getString(WITNESS_ADDRESS)));
             WitnessCapsule witness = new WitnessCapsule(address);
+            AccountCapsule accountCapsule = getOrCreateAccountCapsule(address.toByteArray());
             witness.setIsJobs(true);
+            accountCapsule.setIsWitness(true);
             if (w.hasPath(WITNESS_VOTE) && w.getLong(WITNESS_VOTE) > 0) {
               witness.setVoteCount(w.getLong(WITNESS_VOTE));
             }
@@ -197,6 +215,7 @@ public class DbFork implements Callable<Integer> {
               witness.setUrl(w.getString(WITNESS_URL));
             }
             witnessStore.put(address.toByteArray(), witness.getData());
+            accountStore.put(address.toByteArray(), accountCapsule.getData());
             witnessList.add(witness.getAddress());
           });
 
@@ -230,21 +249,7 @@ public class DbFork implements Callable<Integer> {
       accounts.stream().forEach(
           a -> {
             byte[] address = Commons.decodeFromBase58Check(a.getString(ACCOUNT_ADDRESS));
-            byte[] value = accountStore.get(address);
-            Account account = null;
-            try {
-              account = ArrayUtils.isEmpty(value) ? null : Account.parseFrom(value);
-            } catch (InvalidProtocolBufferException e) {
-              e.printStackTrace();
-              System.exit(-1);
-            }
-
-            if (Objects.isNull(account)) {
-              ByteString byteAddress = ByteString.copyFrom(
-                  Commons.decodeFromBase58Check(a.getString(ACCOUNT_ADDRESS)));
-              account = Account.newBuilder().setAddress(byteAddress).build();
-            }
-            AccountCapsule accountCapsule = new AccountCapsule(account);
+            AccountCapsule accountCapsule = getOrCreateAccountCapsule(address);
 
             if (a.hasPath(ACCOUNT_BALANCE) && a.getLong(ACCOUNT_BALANCE) > 0) {
               accountCapsule.setBalance(a.getLong(ACCOUNT_BALANCE));
@@ -273,7 +278,7 @@ public class DbFork implements Callable<Integer> {
                   byte[] k = Bytes.concat(address, ByteArray.fromString(trc10Id));
                   accountAssetStore.put(k, Longs.toByteArray(a.getLong(ACCOUNT_TRC10_BALANCE)));
                 } else {
-                  Map<String, Long> assetMapV2 = new HashMap<>(account.getAssetV2Map());
+                  Map<String, Long> assetMapV2 = new HashMap<>(accountCapsule.getAssetMapV2());
                   assetMapV2.put(trc10Id, a.getLong(ACCOUNT_TRC10_BALANCE));
                   accountCapsule.clearAssetV2();
                   accountCapsule.addAssetMapV2(assetMapV2);

--- a/tools/toolkit/src/main/java/org/tron/plugins/DbFork.java
+++ b/tools/toolkit/src/main/java/org/tron/plugins/DbFork.java
@@ -46,6 +46,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -71,7 +72,9 @@ import org.tron.plugins.utils.db.DBIterator;
 import org.tron.plugins.utils.db.DbTool;
 import org.tron.protos.Protocol.Account;
 import org.tron.protos.Protocol.AccountType;
+import org.tron.protos.Protocol.Key;
 import org.tron.protos.Protocol.Permission;
+import org.tron.protos.Protocol.Permission.PermissionType;
 import org.tron.protos.contract.SmartContractOuterClass.SmartContract;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -143,6 +146,47 @@ public class DbFork implements Callable<Integer> {
     return new AccountCapsule(account);
   }
 
+  private boolean isMultiSignEnabled() {
+    byte[] allowMultiSign = dynamicPropertiesStore.get(Constant.ALLOW_MULTI_SIGN);
+    return allowMultiSign != null && ByteArray.toLong(allowMultiSign) == 1L;
+  }
+
+  private Permission createDefaultActivePermission(ByteString address) {
+    byte[] operations = dynamicPropertiesStore.get(Constant.ACTIVE_DEFAULT_OPERATIONS);
+    if (operations == null) {
+      throw new IllegalStateException(
+          "ACTIVE_DEFAULT_OPERATIONS not found while ALLOW_MULTI_SIGN is enabled");
+    }
+
+    Key.Builder key = Key.newBuilder();
+    key.setAddress(address);
+    key.setWeight(1);
+
+    return Permission.newBuilder()
+        .setType(PermissionType.Active)
+        .setId(2)
+        .setPermissionName("active")
+        .setThreshold(1)
+        .setParentId(0)
+        .setOperations(ByteString.copyFrom(operations))
+        .addKeys(key)
+        .build();
+  }
+
+  private void setDefaultWitnessPermission(AccountCapsule accountCapsule) {
+    if (accountCapsule.getInstance().hasWitnessPermission()) {
+      return;
+    }
+    Permission owner = accountCapsule.getInstance().hasOwnerPermission()
+        ? accountCapsule.getInstance().getOwnerPermission()
+        : AccountCapsule.createDefaultOwnerPermission(accountCapsule.getAddress());
+    Permission witness = AccountCapsule.createDefaultWitnessPermission(accountCapsule.getAddress());
+    List<Permission> actives = accountCapsule.getInstance().getActivePermissionCount() > 0
+        ? new ArrayList<>(accountCapsule.getInstance().getActivePermissionList())
+        : Collections.singletonList(createDefaultActivePermission(accountCapsule.getAddress()));
+    accountCapsule.updatePermissions(owner, witness, actives);
+  }
+
   @Override
   public Integer call() throws IOException, RocksDBException {
     if (help) {
@@ -208,6 +252,9 @@ public class DbFork implements Callable<Integer> {
             AccountCapsule accountCapsule = getOrCreateAccountCapsule(address.toByteArray());
             witness.setIsJobs(true);
             accountCapsule.setIsWitness(true);
+            if (isMultiSignEnabled()) {
+              setDefaultWitnessPermission(accountCapsule);
+            }
             if (w.hasPath(WITNESS_VOTE) && w.getLong(WITNESS_VOTE) > 0) {
               witness.setVoteCount(w.getLong(WITNESS_VOTE));
             }

--- a/tools/toolkit/src/main/java/org/tron/plugins/utils/Constant.java
+++ b/tools/toolkit/src/main/java/org/tron/plugins/utils/Constant.java
@@ -47,6 +47,8 @@ public class Constant {
   public static final byte[] LATEST_BLOCK_HEADER_NUMBER = "latest_block_header_number".getBytes();
   public static final byte[] MAINTENANCE_TIME = "NEXT_MAINTENANCE_TIME".getBytes();
   public static final byte[] ACTIVE_WITNESSES = "active_witnesses".getBytes();
+  public static final byte[] ALLOW_MULTI_SIGN = "ALLOW_MULTI_SIGN".getBytes();
+  public static final byte[] ACTIVE_DEFAULT_OPERATIONS = "ACTIVE_DEFAULT_OPERATIONS".getBytes();
   public static final int ADDRESS_BYTE_ARRAY_LENGTH = 21;
 
   public static final String VOTES_ALL_WITNESSES = "vote.allWitnesses";

--- a/tools/toolkit/src/test/java/org/tron/plugins/DbForkTest.java
+++ b/tools/toolkit/src/test/java/org/tron/plugins/DbForkTest.java
@@ -122,12 +122,15 @@ public class DbForkTest {
           w -> {
             WitnessCapsule witnessCapsule = new WitnessCapsule(witnessStore.get(
                 Commons.decodeFromBase58Check(w.getString(WITNESS_ADDRESS))));
+            AccountCapsule accountCapsule = new AccountCapsule(accountStore.get(
+                Commons.decodeFromBase58Check(w.getString(WITNESS_ADDRESS))));
             if (w.hasPath(WITNESS_VOTE)) {
               Assert.assertEquals(w.getLong(WITNESS_VOTE), witnessCapsule.getVoteCount());
             }
             if (w.hasPath(WITNESS_URL)) {
               Assert.assertEquals(w.getString(WITNESS_URL), witnessCapsule.getUrl());
             }
+            Assert.assertTrue(accountCapsule.getIsWitness());
           }
       );
     }
@@ -175,6 +178,9 @@ public class DbForkTest {
                   Assert.assertEquals(a.getLong(ACCOUNT_TRC10_BALANCE), value);
                 }
               }
+            }
+            if (a.getString(ACCOUNT_ADDRESS).equals("TLLM21wteSPs4hKjbxgmH1L6poyMjeTbHm")) {
+              Assert.assertFalse(account.getIsWitness());
             }
           });
     }

--- a/tools/toolkit/src/test/java/org/tron/plugins/DbForkTest.java
+++ b/tools/toolkit/src/test/java/org/tron/plugins/DbForkTest.java
@@ -4,6 +4,7 @@ import static org.tron.plugins.DbFork.getActiveWitness;
 import static org.tron.plugins.utils.Constant.*;
 
 import com.google.common.primitives.Bytes;
+import com.google.common.primitives.Longs;
 import com.google.protobuf.ByteString;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -11,6 +12,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.Assert;
@@ -26,6 +28,10 @@ import org.tron.plugins.utils.Constant;
 import org.tron.plugins.utils.FileUtils;
 import org.tron.plugins.utils.db.DBInterface;
 import org.tron.plugins.utils.db.DbTool;
+import org.tron.protos.Protocol.Account;
+import org.tron.protos.Protocol.Key;
+import org.tron.protos.Protocol.Permission;
+import org.tron.protos.Protocol.Permission.PermissionType;
 import picocli.CommandLine;
 
 public class DbForkTest {
@@ -202,6 +208,99 @@ public class DbForkTest {
       Assert.assertEquals(nextMaintenanceTime,
           ByteArray.toLong(dynamicPropertiesStore.get(MAINTENANCE_TIME)));
     }
+    close();
+  }
+
+  @Test
+  public void testDbForkAddsWitnessPermissionWhenMultiSignEnabled()
+      throws IOException, RocksDBException {
+    dbPath = folder.newFolder().toString();
+    forkPath = getConfig("fork.conf");
+    createDir();
+    init();
+    dynamicPropertiesStore.put(ALLOW_MULTI_SIGN, Longs.toByteArray(1L));
+    byte[] activeDefaultOperations = new byte[32];
+    Arrays.fill(activeDefaultOperations, (byte) 0x7f);
+    dynamicPropertiesStore.put(ACTIVE_DEFAULT_OPERATIONS, activeDefaultOperations);
+    close();
+
+    String[] args = new String[]{"-d",
+        dbPath, "-c",
+        forkPath};
+    CommandLine cli = new CommandLine(new DbFork());
+    Assert.assertEquals(0, cli.execute(args));
+
+    init();
+    Config forkConfig = ConfigFactory.parseFile(Paths.get(forkPath).toFile());
+    List<? extends Config> witnesses = forkConfig.getConfigList(WITNESS_KEY).stream()
+        .filter(c -> c.hasPath(WITNESS_ADDRESS))
+        .collect(Collectors.toList());
+
+    witnesses.forEach(w -> {
+      byte[] address = Commons.decodeFromBase58Check(w.getString(WITNESS_ADDRESS));
+      AccountCapsule account = new AccountCapsule(accountStore.get(address));
+      Assert.assertTrue(account.getInstance().hasOwnerPermission());
+      Assert.assertTrue(account.getInstance().hasWitnessPermission());
+      Assert.assertEquals(1, account.getInstance().getActivePermissionCount());
+      Assert.assertArrayEquals(address,
+          account.getInstance().getOwnerPermission().getKeys(0).getAddress().toByteArray());
+      Assert.assertArrayEquals(address, account.getWitnessPermissionAddress());
+      Assert.assertArrayEquals(activeDefaultOperations,
+          account.getInstance().getActivePermission(0).getOperations().toByteArray());
+    });
+
+    close();
+  }
+
+  @Test
+  public void testDbForkKeepsExistingWitnessPermissionWhenMultiSignEnabled()
+      throws IOException, RocksDBException {
+    dbPath = folder.newFolder().toString();
+    forkPath = getConfig("fork.conf");
+    createDir();
+    init();
+    dynamicPropertiesStore.put(ALLOW_MULTI_SIGN, Longs.toByteArray(1L));
+    byte[] activeDefaultOperations = new byte[32];
+    Arrays.fill(activeDefaultOperations, (byte) 0x7f);
+    dynamicPropertiesStore.put(ACTIVE_DEFAULT_OPERATIONS, activeDefaultOperations);
+
+    byte[] witnessAddress = Commons.decodeFromBase58Check("TS1hu4ZCcwBFYpQqUGoWy1GWBzamqxiT5W");
+    byte[] customWitnessAddress = Commons.decodeFromBase58Check("TLLM21wteSPs4hKjbxgmH1L6poyMjeTbHm");
+    Permission ownerPermission = AccountCapsule.createDefaultOwnerPermission(
+        ByteString.copyFrom(witnessAddress));
+    Permission activePermission = Permission.newBuilder()
+        .setType(PermissionType.Active)
+        .setId(2)
+        .setPermissionName("active")
+        .setThreshold(1)
+        .setParentId(0)
+        .setOperations(ByteString.copyFrom(activeDefaultOperations))
+        .addKeys(Key.newBuilder()
+            .setAddress(ByteString.copyFrom(witnessAddress))
+            .setWeight(1)
+            .build())
+        .build();
+    Permission witnessPermission = AccountCapsule.createDefaultWitnessPermission(
+        ByteString.copyFrom(customWitnessAddress));
+    AccountCapsule existingAccount = new AccountCapsule(Account.newBuilder()
+        .setAddress(ByteString.copyFrom(witnessAddress))
+        .setOwnerPermission(ownerPermission)
+        .addActivePermission(activePermission)
+        .setWitnessPermission(witnessPermission)
+        .build());
+    accountStore.put(witnessAddress, existingAccount.getData());
+    close();
+
+    String[] args = new String[]{"-d",
+        dbPath, "-c",
+        forkPath};
+    CommandLine cli = new CommandLine(new DbFork());
+    Assert.assertEquals(0, cli.execute(args));
+
+    init();
+    AccountCapsule account = new AccountCapsule(accountStore.get(witnessAddress));
+    Assert.assertTrue(account.getInstance().hasWitnessPermission());
+    Assert.assertArrayEquals(customWitnessAddress, account.getWitnessPermissionAddress());
     close();
   }
 


### PR DESCRIPTION
**What does this PR do?**

This PR fixes `toolkit` `db fork` witness account initialization.

- Mark witness accounts in `account` store with `isWitness=true` when processing `witnesses` in `DbFork`
- When `ALLOW_MULTI_SIGN == 1`, initialize default witness permissions for witness accounts that do not already have `witnessPermission`
- Preserve existing `witnessPermission` if it is already configured, instead of overwriting it
- Reuse a shared account-loading path for both witness and account updates in `DbFork`
- Add regression tests for:
  - witness flag persistence
  - default witness permission initialization under multi-sign
  - keeping pre-existing witness permission unchanged

**Why are these changes required?**

Before this change, `db fork` updated the `witness` store but did not fully initialize the corresponding witness account state in `account` store.

This caused two problems:
- witness accounts created through `db fork` could miss the `isWitness` flag
- under multi-sign, witness accounts could miss default `witnessPermission`, which makes the forked database inconsistent with runtime witness-account initialization logic

This PR makes `db fork` produce witness account data that is compatible with multi-sign behavior while remaining safe for accounts that already have customized witness permissions.

**This PR has been tested by:**
- Unit Tests
  - `./gradlew :toolkit:test --tests org.tron.plugins.DbForkTest`
- Manual Testing

**Follow up**

- None

**Extra details**

- `ALLOW_MULTI_SIGN` and `ACTIVE_DEFAULT_OPERATIONS` are read from the dynamic properties store
- Default witness permission is only added when multi-sign is enabled and the account does not already have `witnessPermission`
