### PR TITLE
fix: skip SR guard round when node block is stale

### DIFF
--- a/tools/slack_sr_monitor/sr_guard.go
+++ b/tools/slack_sr_monitor/sr_guard.go
@@ -354,6 +354,10 @@ func saveGuardState(previousTop27 []string, nameCache map[string]string) {
 	}
 }
 
+func isBlockFresh(blockTime time.Time) bool {
+	return time.Since(blockTime) <= maxBlockAge
+}
+
 func runSRGuard(tronNodes []string, slackWebhook string, phoneAlertURL string) {
 	phoneLog := "disabled"
 	if phoneAlertURL != "" {
@@ -369,8 +373,12 @@ func runSRGuard(tronNodes []string, slackWebhook string, phoneAlertURL string) {
 	defer ticker.Stop()
 
 	for {
-		witnesses, err := getGuardWitnessListFromNodes(tronNodes)
+		blockTime, err := getLatestBlockTimeFromNodes(tronNodes)
 		if err != nil {
+			log.Printf("skipping SR guard round: failed to get latest block time: %v", err)
+		} else if !isBlockFresh(blockTime) {
+			log.Printf("skipping SR guard round: latest block is stale (age=%s)", time.Since(blockTime))
+		} else if witnesses, err := getGuardWitnessListFromNodes(tronNodes); err != nil {
 			log.Printf("failed to fetch witness list: %v", err)
 		} else {
 			fillDisplayNames(tronNodes, witnesses, nameCache)

--- a/tools/slack_sr_monitor/sr_guard_freshness_test.go
+++ b/tools/slack_sr_monitor/sr_guard_freshness_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestIsBlockFresh(t *testing.T) {
+	if !isBlockFresh(time.Now()) {
+		t.Error("expected current block time to be fresh")
+	}
+	if isBlockFresh(time.Date(2018, time.January, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Error("expected year-2018 block time to be stale")
+	}
+}


### PR DESCRIPTION
**What does this PR do?**

Adds a block freshness gate to the Slack SR guard. Before each poll round, the guard now checks the node's latest block time. If the block is stale (older than 30 seconds) or cannot be fetched, the entire round is skipped: no witness comparison, no alert, and no state update.

**Why are these changes required?**

We hit this in production. A fullnode that was resyncing from genesis kept serving early-chain data (2018-era witness list) while appearing healthy at the HTTP level. The guard compared that stale Top 27 against its saved baseline, produced a false "all 27 SRs changed" alert, triggered a phone call, and polluted its state baseline.

The SR monitor already waits for node freshness before sending maintenance reports. The guard had no equivalent protection, and its per-minute cadence makes it the more likely tool to hit a resyncing node first.

**Changes overview:**

- Add `isBlockFresh` check (latest block age <= 30s) at the start of each guard round
- Skip the round entirely on stale or unavailable block data, leaving state untouched
- Add `sr_guard_freshness_test.go` covering fresh-current-time and 2018-stale-time cases

**This PR has been tested by:**

- `go test ./...` (including new freshness tests)
- `go vet` / `gofmt`
- `go build`
- `docker compose config --quiet`
- Docker Compose deployment on an internal server: verified fresh baseline initialization and normal poll rounds against a healthy fullnode

**Follow up**

- None required. Optionally, when `TRON_NODES` lists multiple nodes, the freshness helper could keep iterating to find a fresh node instead of accepting the first reachable one.

**Extra details**

- The freshness gate runs before the witness list fetch, so a stale round costs only one `/wallet/getnowblock` call
- State JSON is neither read nor written on skipped rounds, so an existing baseline can never be polluted by stale data
- This PR contains a single commit on top of current `develop` (2 files, +24/-1)
